### PR TITLE
Fix FATAL ERROR when FS_specific attribute is missing or empty in VFS config

### DIFF
--- a/src/FSAL/FSAL_VFS/export.c
+++ b/src/FSAL/FSAL_VFS/export.c
@@ -507,7 +507,7 @@ static bool fs_specific_has(const char *fs_specific, const char* key,
 			    char *val, int max_val_bytes)
 {
 	char *fso_copy, *fso_dup, *next_comma, *option;
-	bool ret;
+	bool ret = false;
 
 	if (! fs_specific || ! (fs_specific[0]))
 		goto out;
@@ -530,7 +530,6 @@ static bool fs_specific_has(const char *fs_specific, const char* key,
 		}
 	}
 
-	ret = false;
 cleanup:
 	free(fso_dup);
 out:


### PR DESCRIPTION
This happened in Release build due to uninitialized variable ret in fs_specific_has()
