### PR TITLE
Cache: Fix -ESTALE when inter-directory renaming replaces an existing fi...

### DIFF
--- a/src/Cache_inode/cache_inode_rename.c
+++ b/src/Cache_inode/cache_inode_rename.c
@@ -297,6 +297,13 @@ cache_inode_status_t cache_inode_rename(cache_entry_t *dir_src,
   else
     {
       cache_inode_status_t tmp_status = CACHE_INODE_SUCCESS;
+
+      /* We may have a cache entry for the destination
+       * filename. 
+       * If we do, we must delete it : it is stale.
+       */
+      cache_inode_remove_cached_dirent(dir_dest, newname);
+
       tmp_status = cache_inode_add_cached_dirent(dir_dest,
 						 newname,
 						 lookup_src,


### PR DESCRIPTION
...le.

Test case :

echo toto > dir1/toto
cat dir1/toto
echo titi > dir2/titi
cat dir2/titi
mv dir2/titi dir1/toto
cat dir1/toto       <<<<<------ open returns -ESTALE

Signed-off-by: Simon Derr simon.derr@bull.net
