### PR TITLE
9P/RDMA: Protect send buffers against early re-use

### DIFF
--- a/src/MainNFSD/9p_rdma_callbacks.c
+++ b/src/MainNFSD/9p_rdma_callbacks.c
@@ -123,9 +123,12 @@ void _9p_rdma_process_request( _9p_request_data_t * preq9p, nfs_worker_data_t * 
       if (rc == 1)
        {
          poutdata->size = outdatalen ;
-         msk_post_send( trans, poutdata, outdatamr->mr, _9p_rdma_callback_send, (void*) outdatamr ) ;
-       } else {
-             /* Unlock the buffer right away since we won't use it after all. */
+         if (0 != msk_post_send( trans, poutdata, outdatamr->mr, _9p_rdma_callback_send, (void*) outdatamr ))
+                 rc = -1;
+       } 
+       
+       if (rc != 1)  {
+             /* Unlock the buffer right away since no message is being sent */
              pthread_mutex_lock(&outdatamr->lock);
        }
 

--- a/src/MainNFSD/9p_rdma_callbacks.c
+++ b/src/MainNFSD/9p_rdma_callbacks.c
@@ -59,7 +59,8 @@
 void DispatchWork9P( request_data_t *preq );
 
 void _9p_rdma_callback_send(msk_trans_t *trans, void *arg) {
-
+      _9p_datamr_t * outdatamr =  (_9p_datamr_t*) arg;
+      pthread_mutex_unlock(&outdatamr->lock);
 }
 
 void _9p_rdma_callback_disconnect(msk_trans_t *trans) {
@@ -107,6 +108,9 @@ void _9p_rdma_process_request( _9p_request_data_t * preq9p, nfs_worker_data_t * 
       /* Use buffer received via RDMA as a 9P message */
       preq9p->_9pmsg = pdata->data ;
 
+      /* We start using the send buffer. Lock it. */
+      pthread_mutex_lock(&outdatamr->lock);
+
       if ( ( rc = _9p_process_buffer( preq9p, pworker_data, poutdata->data, &outdatalen ) ) != 1 )
        {
          LogMajor( COMPONENT_9P, "Could not process 9P buffer on socket #%lu", preq9p->pconn->trans_data.sockfd ) ;
@@ -119,8 +123,12 @@ void _9p_rdma_process_request( _9p_request_data_t * preq9p, nfs_worker_data_t * 
       if (rc == 1)
        {
          poutdata->size = outdatalen ;
-         msk_post_send( trans, poutdata, outdatamr->mr, _9p_rdma_callback_send, NULL ) ;
+         msk_post_send( trans, poutdata, outdatamr->mr, _9p_rdma_callback_send, (void*) outdatamr ) ;
+       } else {
+             /* Unlock the buffer right away since we won't use it after all. */
+             pthread_mutex_lock(&outdatamr->lock);
        }
+
 
       _9p_DiscardFlushHook(preq9p);
    }

--- a/src/MainNFSD/9p_rdma_dispatcher.c
+++ b/src/MainNFSD/9p_rdma_dispatcher.c
@@ -198,6 +198,7 @@ void * _9p_rdma_thread( void * Arg )
       rdata[i]->max_size=_9P_RDMA_CHUNK_SIZE ;
       datamr[i].data = rdata[i];
       datamr[i].mr = mr;
+      pthread_mutex_init(&datamr[i].lock, NULL);
 
       if( i < _9P_RDMA_OUT )
         datamr[i].sender = &datamr[i+_9P_RDMA_OUT] ;

--- a/src/include/9p.h
+++ b/src/include/9p.h
@@ -368,6 +368,7 @@ typedef struct _9p_datamr
   msk_data_t *data;
   struct ibv_mr *mr;
   struct _9p_datamr * sender ;
+  pthread_mutex_t lock;
 } _9p_datamr_t ;
 
 typedef struct _9p_rdma_priv


### PR DESCRIPTION

For 9P/RDMA, ganesha has two sets of buffers : recv and send buffers.
Each recv buffer is associated to a send buffer.
When a request is received on a recv buffer, it is processed and the associated
send buffer is used to send the reply.

But the current code fails to check that the previous message that was to be
sent using this send buffer has actually been sent and that this buffer can
be reused. In case of high traffic, this leads to buffer overwriting and
duplicate messages.

This patch adds a mutex to each buffer. Before processing a request, the mutex
is taken, and it will be released after the reply has been sent. If another request
wants to use the send buffer, it will have to wait for the message to be really
sent.