### PR TITLE
Populate the right value for fh_desc->len in ceph FSAL

### DIFF
--- a/src/FSAL/FSAL_CEPH/export.c
+++ b/src/FSAL/FSAL_CEPH/export.c
@@ -182,7 +182,7 @@ static fsal_status_t extract_handle(struct fsal_export *exp_hdl,
 	case FSAL_DIGEST_NFSV3:
 	case FSAL_DIGEST_NFSV4:
 		/* wire handles */
-		fh_desc->len = sizeof(wire->vi); /* vinodeno_t */
+		fh_desc->len = sizeof(struct wire_handle);
 		break;
 		/* Integer IDs */
 	case FSAL_DIGEST_FILEID2:


### PR DESCRIPTION
The len field in fh_desc should be size of struct wire_handle,
otherwise the subsequent create_handle will fail since
desc->len != sizeof(struct wire_handle.