### PR TITLE
check for stable writes in vfs_write was incorrect

### DIFF
--- a/src/FSAL/FSAL_VFS/file.c
+++ b/src/FSAL/FSAL_VFS/file.c
@@ -155,7 +155,7 @@ fsal_status_t vfs_write(struct fsal_obj_handle *obj_hdl,
 	*write_amount = nb_written;
 
 	/* attempt stability */
-	if (*fsal_stable) {
+	if (fsal_stable) {
 		retval = fsync(myself->u.file.fd);
 		if (retval == -1) {
 			retval = errno;


### PR DESCRIPTION
the code block should be checking if the pointer "fsal_stable" is non-NULL and not whether its actual value is true.