### PR TITLE
pthread_mutex_attr_t not being freed

### DIFF
--- a/src/FSAL/fsal_manager.c
+++ b/src/FSAL/fsal_manager.c
@@ -458,12 +458,9 @@ int register_fsal(struct fsal_module *fsal_hdl, const char *name,
 		goto errout;
 	}
 	memcpy(fsal_hdl->ops, &def_fsal_ops, sizeof(struct fsal_ops));
-
-	pthread_mutexattr_init(&attrs);
-#if defined(__linux__)
-	pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_ADAPTIVE_NP);
-#endif
-	pthread_mutex_init(&fsal_hdl->lock, &attrs);
+	
+	mutex_init(&fsal_hdl->lock, &attrs);
+	
 	glist_init(&fsal_hdl->fsals);
 	glist_init(&fsal_hdl->exports);
 	glist_add_tail(&fsal_list, &fsal_hdl->fsals);


### PR DESCRIPTION
pthread_mutex_t was initialized but pthread_mutex_attr_t was not being freed.

changed call to use mutex_init() instead.