### PR TITLE
NFSv4: Fixed max path length issue for symlinks.

### DIFF
--- a/src/Protocols/NFS/nfs_proto_tools.c
+++ b/src/Protocols/NFS/nfs_proto_tools.c
@@ -4087,7 +4087,7 @@ nfsstat4 nfs4_utf8string2dynamic(const utf8string *input,
 	if (input->utf8string_val == NULL || input->utf8string_len == 0)
 		return NFS4ERR_INVAL;
 
-	if (input->utf8string_len > MAXNAMLEN)
+	if (input->utf8string_len > MAXPATHLEN)
 		return NFS4ERR_NAMETOOLONG;
 
 	char *name = gsh_malloc(input->utf8string_len + 1);


### PR DESCRIPTION
Changes: Use MAXPATHLEN instead of MAXNAMLEN value to verify the length of path to target for symlink.

Steps to reproduce:
1. Mount the share with NFSv4;
2. Try to create symlink on the file with path more than 256 symbols;
3. Get the next error:

ln -s ./_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789/_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789 FILENAME

ln: creating symbolic link `FILENAME' -> `./_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789/_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789': File name too long

If the path is less than 256 symblols - all is OK.