### PR TITLE
Convert FSAL_VFS/panfs to work with the new pnfs_device format.

### DIFF
--- a/src/FSAL/FSAL_VFS/export.c
+++ b/src/FSAL/FSAL_VFS/export.c
@@ -630,6 +630,7 @@ fsal_status_t vfs_create_export(struct fsal_module *fsal_hdl,
 				       &err_type);
 	if (retval != 0)
 		return fsalstat(ERR_FSAL_INVAL, 0);
+	myself->export.fsal = fsal_hdl;
 	vfs_init_export_ops(myself, op_ctx->export->fullpath);
 
 	retval = fsal_attach_export(fsal_hdl, &myself->export.exports);
@@ -637,7 +638,6 @@ fsal_status_t vfs_create_export(struct fsal_module *fsal_hdl,
 		fsal_error = posix2fsal_error(retval);
 		goto errout;	/* seriously bad */
 	}
-	myself->export.fsal = fsal_hdl;
 
 	retval = populate_posix_file_systems();
 

--- a/src/FSAL/FSAL_VFS/handle_syscalls.c
+++ b/src/FSAL/FSAL_VFS/handle_syscalls.c
@@ -148,6 +148,7 @@ void vfs_init_export_ops(struct vfs_fsal_export *myself,
 			export_path);
 		export_ops_pnfs(myself->export.ops);
 		handle_ops_pnfs(myself->export.obj_ops);
+		fsal_ops_pnfs(myself->export.fsal->ops);
 	}
 }
 

--- a/src/FSAL/FSAL_VFS/pnfs_panfs/mds.h
+++ b/src/FSAL/FSAL_VFS/pnfs_panfs/mds.h
@@ -38,6 +38,8 @@
 void export_ops_pnfs(struct export_ops *ops);
 /* Need to call this to initialize obj_ops for pnfs */
 void handle_ops_pnfs(struct fsal_obj_ops *ops);
+/* Need to call this to initialize ops for pnfs */
+void fsal_ops_pnfs(struct fsal_ops *ops);
 
 /* Start the up calls thread for LAYOUT RECALLS*/
 int pnfs_panfs_init(int root_fd, void **pnfs_data /*OUT*/);

--- a/src/Protocols/NFS/nfs4_op_getdeviceinfo.c
+++ b/src/Protocols/NFS/nfs4_op_getdeviceinfo.c
@@ -104,7 +104,7 @@ int nfs4_op_getdeviceinfo(struct nfs_argop4 *op, compound_data_t *data,
 
 	if (deviceid->fsal_id >= FSAL_ID_COUNT) {
 		LogInfo(COMPONENT_PNFS,
-			"GETDEVICEINFO with invalid fsal id %c",
+			"GETDEVICEINFO with invalid fsal id %0hhx",
 			deviceid->fsal_id);
 		return res_GETDEVICEINFO4->gdir_status = NFS4ERR_INVAL;
 	}
@@ -113,7 +113,7 @@ int nfs4_op_getdeviceinfo(struct nfs_argop4 *op, compound_data_t *data,
 
 	if (fsal == NULL) {
 		LogInfo(COMPONENT_PNFS,
-			"GETDEVICEINFO with inactive fsal id %c",
+			"GETDEVICEINFO with inactive fsal id %0hhx",
 			deviceid->fsal_id);
 		return res_GETDEVICEINFO4->gdir_status = NFS4ERR_INVAL;
 	}


### PR DESCRIPTION
The pnfs_device format recently changed to have structure in the first
64-bits, as opposed to storing an export ID in that field.  Convert the
panfs implementation in FSAL_VFS to use this new format.

Signed-off-by: Daniel Gryniewicz <dang@linuxbox.com>