### PR TITLE
miscellaneous one-liner initializations needed because

### DIFF
--- a/src/FSAL/commonlib.c
+++ b/src/FSAL/commonlib.c
@@ -745,7 +745,7 @@ int re_index_fs_dev(struct fsal_filesystem *fs,
 int change_fsid_type(struct fsal_filesystem *fs,
 		     enum fsid_type fsid_type)
 {
-	uint64_t major, minor;
+	uint64_t major = 0, minor = 0;
 	bool valid = false;
 
 	if (fs->fsid_type == fsid_type)

--- a/src/Protocols/NFS/nfs3_setattr.c
+++ b/src/Protocols/NFS/nfs3_setattr.c
@@ -74,7 +74,7 @@ int nfs3_setattr(nfs_arg_t *arg,
 	pre_op_attr pre_attr = {
 		.attributes_follow = false
 	};
-	cache_inode_status_t cache_status;
+	cache_inode_status_t cache_status = CACHE_INODE_SUCCESS;
 	int rc = NFS_REQ_OK;
 
 	if (isDebug(COMPONENT_NFSPROTO)) {

--- a/src/Protocols/NFS/nfs4_op_secinfo.c
+++ b/src/Protocols/NFS/nfs4_op_secinfo.c
@@ -65,7 +65,7 @@ int nfs4_op_secinfo(struct nfs_argop4 *op, compound_data_t *data,
 	cache_entry_t *entry_src = NULL;
 	sec_oid4 v5oid = { krb5oid.length, (char *)krb5oid.elements };
 	int num_entry = 0;
-	struct export_perms save_export_perms;
+	struct export_perms save_export_perms = { 0, };
 	struct gsh_export *saved_gsh_export = NULL;
 
 	resp->resop = NFS4_OP_SECINFO;

--- a/src/Protocols/NFS/nfs4_op_write.c
+++ b/src/Protocols/NFS/nfs4_op_write.c
@@ -153,7 +153,7 @@ static int nfs4_write(struct nfs_argop4 *op, compound_data_t *data,
 {
 	WRITE4args * const arg_WRITE4 = &op->nfs_argop4_u.opwrite;
 	WRITE4res * const res_WRITE4 = &resp->nfs_resop4_u.opwrite;
-	uint64_t size;
+	uint64_t size = 0;
 	size_t written_size;
 	uint64_t offset;
 	bool eof_met;

--- a/src/Protocols/NFS/nfs4_pseudo.c
+++ b/src/Protocols/NFS/nfs4_pseudo.c
@@ -297,7 +297,7 @@ bool pseudo_mount_export(struct gsh_export *export)
 	char *rest;
 	cache_inode_status_t cache_status;
 	char *tok;
-	char *saveptr;
+	char *saveptr = NULL;
 	int rc;
 
 	/* skip exports that aren't for NFS v4

--- a/src/Protocols/NLM/sm_notify.c
+++ b/src/Protocols/NLM/sm_notify.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 {
 	int c;
 	int port = 0;
-	int state, sflag = 0;
+	int state = 0, sflag = 0;
 	char mon_client[STR_SIZE], mflag = 0;
 	char remote_addr_s[STR_SIZE], rflag = 0;
 	char local_addr_s[STR_SIZE], lflag = 0;

--- a/src/cache_inode/cache_inode_getattr.c
+++ b/src/cache_inode/cache_inode_getattr.c
@@ -71,7 +71,7 @@ cache_inode_getattr(cache_entry_t *entry,
 		    cache_inode_getattr_cb_t cb)
 {
 	cache_inode_status_t status;
-	struct gsh_export *junction_export;
+	struct gsh_export *junction_export = NULL;
 	cache_entry_t *junction_entry;
 	uint64_t mounted_on_fileid;
 

--- a/src/config_parsing/config_parsing.c
+++ b/src/config_parsing/config_parsing.c
@@ -1576,7 +1576,7 @@ int find_config_nodes(config_file_t config, char *expr_str,
 	struct config_node *sub_node;
 	struct config_node *top;
 	struct expr_parse *expr, *expr_head;
-	struct config_node_list *list = NULL, *list_tail;
+	struct config_node_list *list = NULL, *list_tail = NULL;
 	char *ep;
 	int rc = EINVAL;
 	bool found = false;

--- a/src/scripts/systemd/sysconfig/nfs-ganesha
+++ b/src/scripts/systemd/sysconfig/nfs-ganesha
@@ -1,1 +1,1 @@
-OPTIONS="-d -L /var/log/ganesha.log -f /etc/ganesha.nfsd.conf -N NIV_EVENT"
+OPTIONS="-d -L /var/log/ganesha.log -f /etc/ganesha/ganesha.conf -N NIV_EVENT"


### PR DESCRIPTION
_hardened_build for Fedora and EPEL adds -Wuninitialized -Werror
to the standard options provided by cmake

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>