### PR TITLE
FSAL_CEPH: memset the parameter 'buf' passed to ceph_ll_readlink function

### DIFF
--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -566,6 +566,7 @@
 	number of alternate gids to 16.
       -	RPM packaging has been restructured and updated.  The DBus tools
 	are now packaged.
+
 2.2.0 - Tue 21 Apr 2015
       - Ganesha supports granting delegations
       - There have been numerous config changes

--- a/src/FSAL/FSAL_CEPH/handle.c
+++ b/src/FSAL/FSAL_CEPH/handle.c
@@ -368,6 +368,7 @@ static fsal_status_t fsal_readlink(struct fsal_obj_handle *link_pub,
 	/* Pointer to the Ceph link content */
 	char content[PATH_MAX];
 
+	memset(content, 0, sizeof(content));
 	/* Content points into a static buffer in the Ceph client's
 	   cache, so we don't have to free it. */
 

--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,22 @@
+nfs-ganesha (2.2.0-1) stable; urgency=log
+
+  * Ganesha supports granting delegations
+  * There have been numerous config changes
+  * Ganesha now includes systemd scripts
+  * Improved packaging for RPM and Debian
+  * Major stability improvements
+  * non-QT based python tools
+  * Support for Ganesha to be a pNFS DS only, no MDS
+  * SECINFO in preferred order
+  * LTTng support
+  * NFS v4.2 support
+  * Major improvements in 9p support
+  * Code cleanup (checkpatch and Coverity)
+  * ntirpc improvements
+  * FSAL_GLUSTER updated with pNFS and ACL support and more
+
+ -- Philippe Deniel <philippe.deniel@>  Wed, 22 Apr 2015 15:30:00 +0200
+
 nfs-ganesha (2.1.0-1) stable; urgency=log
 
   * Updates for the debian packaging using the cmake build system

--- a/src/nfs-ganesha.spec-in.cmake
+++ b/src/nfs-ganesha.spec-in.cmake
@@ -584,6 +584,22 @@ make DESTDIR=%{buildroot} install
 %endif
 
 %changelog
+* Tue Apr 21 2015  Philippe DENIEL <philippe.deniel@cea.fr> 2.2
+- Ganesha supports granting delegations
+- There have been numerous config changes
+- Ganesha now includes systemd scripts
+- Improved packaging for RPM and Debian
+- Major stability improvements
+- non-QT based python tools
+- Support for Ganesha to be a pNFS DS only, no MDS
+- SECINFO in preferred order
+- LTTng support
+- NFS v4.2 support
+- Major improvements in 9p support
+- Code cleanup (checkpatch and Coverity)
+- ntirpc improvements
+- FSAL_GLUSTER updated with pNFS and ACL support and more
+
 * Fri Jun 27 2014  Philippe DENIEL <philippe.deniel@cea.fr> 2.1
 - Exports are now dynamic.  They can be added or removed via DBus commands.
 - The Pseudo filesystem has been re-written as a FSAL


### PR DESCRIPTION
FSAL_CEPH: There are lots of soft link (created by ln command)  in the cephfs directory, and they were exported by nfs-ganesha, when I run  ls command in the nfs client, messy code will be got at the end of the name of the soft link, which will cause the soft link unusable.
