### PR TITLE
Remove references to removed files

### DIFF
--- a/src/debian/nfs-ganesha-doc.docs
+++ b/src/debian/nfs-ganesha-doc.docs
@@ -1,3 +1,1 @@
 COMPILING_HOWTO.txt
-Docs/nfs-ganesha-adminguide.pdf
-Docs/nfs-ganesha-userguide.pdf


### PR DESCRIPTION
These files were removed in 4cc5b3e7d4f3a42524dd849b6112e0e2e6681ce1 but
not removed from the debian files.
