### PR TITLE
Put the whole /usr folder in .deb

### DIFF
--- a/src/debian/nfs-ganesha.install
+++ b/src/debian/nfs-ganesha.install
@@ -2,4 +2,4 @@ etc/ganesha/ganesha.conf
 etc/logrotate.d/nfs-ganesha
 etc/init.d/nfs-ganesha
 etc/dbus-1/system.d/nfs-ganesha-dbus.conf
-usr/bin/ganesha.nfsd
+usr


### PR DESCRIPTION
Without it, libraries such as libntirpc.so are not included in the final
debian folder, so shlibdeps will fail to find them (and a debian machine
with the package installed won't find it either)
