### PR TITLE
FSAL_CEPH: Set mask to GID when changing group ownership

### DIFF
--- a/src/FSAL/FSAL_CEPH/handle.c
+++ b/src/FSAL/FSAL_CEPH/handle.c
@@ -1974,7 +1974,7 @@ fsal_status_t ceph_setattr2(struct fsal_obj_handle *obj_hdl,
 	}
 
 	if (FSAL_TEST_MASK(attrib_set->mask, ATTR_GROUP)) {
-		mask |= CEPH_SETATTR_UID;
+		mask |= CEPH_SETATTR_GID;
 		st.st_gid = attrib_set->group;
 	}
 


### PR DESCRIPTION
Since we are changing the GID of a file we need to set the mask to
CEPH_SETATTR_GID so that we modify the right attribute of a file.

In the current situation the UID is set back to 0 without changing the GID.

Seems this was a small copy/paste bug which sneaked in.

Signed-off-by: Wido den Hollander <wido@widodh.nl>