### PR TITLE
RGW: failing to bind to librados should be caught

### DIFF
--- a/src/FSAL/FSAL_RGW/main.c
+++ b/src/FSAL/FSAL_RGW/main.c
@@ -173,7 +173,7 @@ static fsal_status_t create_export(struct fsal_module *module_in,
 	/* The status code to return */
 	fsal_status_t status = { ERR_FSAL_NO_ERROR, 0 };
 	/* The internal export object */
-	struct rgw_export *export;
+	struct rgw_export *export = NULL;
 	/* The 'private' root handle */
 	struct rgw_handle *handle = NULL;
 	/* Stat for root */
@@ -242,6 +242,11 @@ static fsal_status_t create_export(struct fsal_module *module_in,
 				gsh_free(inst_name);
 		}
 		PTHREAD_MUTEX_unlock(&init_mtx);
+	}
+
+	if (rc != 0) {
+		status.major = ERR_FSAL_BAD_INIT;
+		goto error;
 	}
 
 	export = gsh_calloc(1, sizeof(struct rgw_export));


### PR DESCRIPTION
If librados initialization fails and is unhandled, the rgw_mount() code
path ultimately causes a segfault. Check the status of librgw_create()
and handle accordingly.

Fixes #112

Change-Id: Ie95caf6b2329e87c30552cf97e018133f0b219d9
Signed-off-by: Karol Mroz kmroz@suse.de
(cherry picked from commit edf4f579897f5cea71339c444800cf910e03325d)
