### PR TITLE
Fix SSE4_2 compile path.

### DIFF
--- a/src/support/city.c
+++ b/src/support/city.c
@@ -494,7 +494,7 @@ static void CityHashCrc256Long(const char *s, size_t len, uint32 seed,
 		h = _mm_crc32_u64(h, c);				\
 		i = _mm_crc32_u64(i, d);				\
 		j = _mm_crc32_u64(j, e);				\
-		s += 40							\
+		s += 40;						\
 	} while (0)
 
 		CHUNK(1, 1);


### PR DESCRIPTION
A semicolon has been missing from the "CHUNK" macro since it was
reformatted.

Signed-off-by: Dylan Reid <dgreid@chromium.org>