### PR TITLE
When ganesha.nfsd over ceph-rgw(>=10.2.8), EIO may happen because rgw reject the partial-write or out-of-order-write(ceph/ceph#10284)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR CMAKE_INSTALL_PREFIX STREQU
 # Patch level is always ".0" for mainline (master).  It is blank for development.
 # When starting a stable maintenance branch, this becomes ".N"
 # where N is monotonically increasing starting at 1. Remember to include the "." !!
-set(GANESHA_PATCH_LEVEL .1)
+set(GANESHA_PATCH_LEVEL .1.1)
 
 # Extra version is for naming development/RC.  It is blank in master/stable branches
 # so it can be available to end-users to name local variants/versions

--- a/src/FSAL/FSAL_RGW/internal.c
+++ b/src/FSAL/FSAL_RGW/internal.c
@@ -210,6 +210,7 @@ int construct_handle(struct rgw_export *export,
 	handle_ops_init(&constructing->handle.obj_ops);
 	constructing->handle.fsid = posix2fsal_fsid(st->st_dev);
 	constructing->handle.fileid = st->st_ino;
+	constructing->handle.rgw_write_offset = 0;
 
 	constructing->export = export;
 

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -3140,6 +3140,7 @@ struct fsal_obj_handle {
 				   stored */
 	uint64_t fileid;	/*< Unique identifier for this object within
 				   the scope of the fsid, (e.g. inode number) */
+	uint64_t rgw_write_offset;
 
 	struct state_hdl *state_hdl;	/*< State related to this handle */
 };


### PR DESCRIPTION
Two reasons:
-1- mount without the sync option. OS's buffer IO may flush the block to vfs out-of-order;
-2- mount with the sync option. Try 'dd if=/dev/zero of=./f0 bs=100 count=1024', found that nfs.client send the data by (begin_offset, end_offset] in (0,100] (0,200] (0,300]...(0,4096]. When the rgw_file has wrote the (0,100], it would update the offset to 100, but the (0,200] make the rgw return EIO. This bugfix add a rgw_write_offset in struct fsal_obj_handle for current file write offset, and skip the data that has wrote before. For example, after write the (0,100] to rgw, rgw_write_offset=100; then (0,200], skip the (0,100], send (100,200], rgw_write_offset=200;