### PR TITLE
vfs: Add pNFS support and MDCACHE.

### DIFF
--- a/src/FSAL/FSAL_VFS/vfs/CMakeLists.txt
+++ b/src/FSAL/FSAL_VFS/vfs/CMakeLists.txt
@@ -12,6 +12,8 @@ SET(fsalvfs_LIB_SRCS
    ../xattrs.c
    ../vfs_methods.h
    ../state.c
+   mds.c
+   ds.c
    subfsal_vfs.c
   )
 

--- a/src/FSAL/FSAL_VFS/vfs/ds.c
+++ b/src/FSAL/FSAL_VFS/vfs/ds.c
@@ -1,0 +1,315 @@
+/*
+ *
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright © 2012 CohortFS, LLC.
+ * Author: Adam C. Emerson <aemerson@linuxbox.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+/**
+ * @file   ds.c
+ *
+ * @brief pNFS DS operations for VFS
+ *
+ * This file implements the read, write, commit, and dispose
+ * operations for VFS data-server handles.
+ *
+ * Also, creating a data server handle -- now called via the DS itself.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include "fsal_api.h"
+#include "FSAL/access_check.h"
+#include "fsal_convert.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include "FSAL/fsal_commonlib.h"
+#include "../../fsal_private.h"
+#include "../vfs_methods.h"
+#include "pnfs_utils.h"
+#include "nfs_exports.h"
+#include "nfs_creds.h"
+
+/**
+ * @brief Release a DS handle
+ *
+ * @param[in] ds_pub The object to release
+ */
+static void
+vfs_release(struct fsal_ds_handle *const ds_pub)
+{
+	/* The private 'full' DS handle */
+	struct vfs_ds *ds = container_of(ds_pub,
+					    struct vfs_ds,
+					    ds);
+
+	fsal_ds_handle_fini(&ds->ds);
+	gsh_free(ds);
+}
+
+/**
+ * @brief Read from a data-server handle.
+ *
+ * NFSv4.1 data server handles are disjount from normal
+ * filehandles (in Ganesha, there is a ds_flag in the filehandle_v4_t
+ * structure) and do not get loaded into cache_inode or processed the
+ * normal way.
+ *
+ * @param[in]  ds_pub           FSAL DS handle
+ * @param[in]  req_ctx          Credentials
+ * @param[in]  stateid          The stateid supplied with the READ operation,
+ *                              for validation
+ * @param[in]  offset           The offset at which to read
+ * @param[in]  requested_length Length of read requested (and size of buffer)
+ * @param[out] buffer           The buffer to which to store read data
+ * @param[out] supplied_length  Length of data read
+ * @param[out] eof              True on end of file
+ *
+ * @return An NFSv4.1 status code.
+ */
+static nfsstat4
+vfs_ds_read(struct fsal_ds_handle *const ds_pub,
+		struct req_op_context *const req_ctx,
+		const stateid4 *stateid,
+		const offset4 offset,
+		const count4 requested_length,
+		void *const buffer,
+		count4 *const supplied_length,
+		bool *const end_of_file)
+{
+	/* The private 'full' DS handle */
+	struct vfs_ds *ds = container_of(ds_pub, struct vfs_ds, ds);
+	struct vfs_file_handle *vfs_handle = &ds->wire;
+	/* The amount actually read */
+	int amount_read = 0;
+	int fd = 0;
+
+	/* @todo: we could take care of parameter stability_wanted here */
+	fsal_errors_t fsal_error = ERR_FSAL_NO_ERROR;
+	fd = vfs_open_by_handle(ds->vfs_fs,
+	                        vfs_handle, O_RDONLY|O_NOFOLLOW|O_SYNC, &fsal_error);
+	if (fd < 0)
+		return posix2nfs4_error(errno);
+
+	/* write the data */
+	amount_read = pread(fd, buffer, requested_length, offset);
+	if (amount_read < 0) {
+		/* ignore any potential error on close if read failed? */
+		close(fd);
+		return posix2nfs4_error(-amount_read);
+	}
+
+	if (close(fd) < 0)
+		return posix2nfs4_error(errno);
+
+
+	*supplied_length = amount_read;
+	*end_of_file = amount_read == 0 ? true : false;
+
+	return NFS4_OK;
+}
+
+/**
+ *
+ * @brief Write to a data-server handle.
+ *
+ * This performs a DS write not going through the data server unless
+ * FILE_SYNC4 is specified, in which case it connects the filehandle
+ * and performs an MDS write.
+ *
+ * @param[in]  ds_pub           FSAL DS handle
+ * @param[in]  req_ctx          Credentials
+ * @param[in]  stateid          The stateid supplied with the READ operation,
+ *                              for validation
+ * @param[in]  offset           The offset at which to read
+ * @param[in]  write_length     Length of write requested (and size of buffer)
+ * @param[out] buffer           The buffer to which to store read data
+ * @param[in]  stability wanted Stability of write
+ * @param[out] written_length   Length of data written
+ * @param[out] writeverf        Write verifier
+ * @param[out] stability_got    Stability used for write (must be as
+ *                              or more stable than request)
+ *
+ * @return An NFSv4.1 status code.
+ */
+static nfsstat4
+vfs_ds_write(struct fsal_ds_handle *const ds_pub,
+		struct req_op_context *const req_ctx,
+		const stateid4 *stateid,
+		const offset4 offset,
+		const count4 write_length,
+		const void *buffer,
+		const stable_how4 stability_wanted,
+		count4 *written_length,
+		verifier4 *writeverf,
+		stable_how4 *stability_got)
+{
+	/* The private 'full' DS handle */
+	struct vfs_ds *ds = container_of(ds_pub, struct vfs_ds, ds);
+	struct vfs_file_handle *vfs_handle = &ds->wire;
+	/* The amount actually read */
+	int32_t amount_written = 0;
+	int fd = 0;
+
+	memset(writeverf, 0, NFS4_VERIFIER_SIZE);
+
+	/** @todo Add some debug code here about the fh to be used */
+
+	/* @todo: we could take care of parameter stability_wanted here */
+	fsal_errors_t fsal_error = ERR_FSAL_NO_ERROR;
+	fd = vfs_open_by_handle(ds->vfs_fs,
+	                        vfs_handle, O_WRONLY|O_NOFOLLOW|O_SYNC, &fsal_error);
+	if (fd < 0)
+		return posix2nfs4_error(errno);
+
+	/* write the data */
+	amount_written = pwrite(fd, buffer, write_length, offset);
+	if (amount_written < 0) {
+		close(fd);
+		return posix2nfs4_error(-amount_written);
+	}
+
+	if (close(fd) < 0)
+		return posix2nfs4_error(errno);
+
+	*written_length = amount_written;
+	*stability_got = stability_wanted;
+
+	return NFS4_OK;
+}
+
+/**
+ * @brief Commit a byte range to a DS handle.
+ *
+ * NFSv4.1 data server filehandles are disjount from normal
+ * filehandles (in Ganesha, there is a ds_flag in the filehandle_v4_t
+ * structure) and do not get loaded into cache_inode or processed the
+ * normal way.
+ *
+ * @param[in]  ds_pub    FSAL DS handle
+ * @param[in]  req_ctx   Credentials
+ * @param[in]  offset    Start of commit window
+ * @param[in]  count     Length of commit window
+ * @param[out] writeverf Write verifier
+ *
+ * @return An NFSv4.1 status code.
+ */
+
+
+static nfsstat4
+vfs_ds_commit(struct fsal_ds_handle *const ds_pub,
+		 struct req_op_context *const req_ctx,
+		 const offset4 offset,
+		 const count4 count,
+		 verifier4 *const writeverf)
+{
+	memset(writeverf, 0, NFS4_VERIFIER_SIZE);
+	return NFS4_OK;
+}
+
+static void
+dsh_ops_init(struct fsal_dsh_ops *ops)
+{
+	memcpy(ops, &def_dsh_ops, sizeof(struct fsal_dsh_ops));
+
+	ops->release = vfs_release;
+	ops->read = vfs_ds_read;
+	ops->write = vfs_ds_write;
+	ops->commit = vfs_ds_commit;
+}
+
+/**
+ * @brief Try to create a FSAL data server handle
+ *
+ * @param[in]  pds      FSAL pNFS DS
+ * @param[in]  desc     Buffer from which to create the file
+ * @param[out] handle   FSAL DS handle
+ *
+ * @return NFSv4.1 error codes.
+ */
+
+static nfsstat4 make_ds_handle(struct fsal_pnfs_ds *const pds,
+			       const struct gsh_buffdesc *const desc,
+			       struct fsal_ds_handle **const handle,
+			       int flags)
+{
+	struct vfs_file_handle *vfs_fh =
+					(struct vfs_file_handle *)desc->addr;
+	struct vfs_ds *ds;		/* Handle to be created */
+	struct fsal_filesystem *fs;
+	struct fsal_fsid__ fsid;
+	enum fsid_type fsid_type;
+
+	*handle = NULL;
+
+	if (desc->len != sizeof(struct vfs_file_handle))
+		return NFS4ERR_BADHANDLE;
+
+	vfs_extract_fsid(vfs_fh, &fsid_type, &fsid);
+
+	fs = lookup_fsid(&fsid, fsid_type);
+	if (fs == NULL) {
+		LogInfo(COMPONENT_FSAL,
+			"Could not find filesystem for fsid=0x%016"PRIx64
+			".0x%016"PRIx64" from handle",
+			fsid.major, fsid.minor);
+		return NFS4ERR_STALE;
+	}
+
+	if (fs->fsal != pds->fsal) {
+		LogInfo(COMPONENT_FSAL,
+			"Non VFS filesystem fsid=0x%016"PRIx64
+			".0x%016"PRIx64" from handle",
+			fsid.major, fsid.minor);
+		return NFS4ERR_STALE;
+	}
+
+	ds = gsh_calloc(1, sizeof(struct vfs_ds));
+
+	*handle = &ds->ds;
+	fsal_ds_handle_init(*handle, pds);
+
+	/* Connect lazily when a FILE_SYNC4 write forces us to, not
+	   here. */
+
+	ds->connected = false;
+
+	ds->vfs_fs = fs->private_data;
+
+	memcpy(&ds->wire, desc->addr, desc->len);
+	return NFS4_OK;
+}
+
+static nfsstat4 pds_permissions(struct fsal_pnfs_ds *const pds,
+				struct svc_req *req)
+{
+	/* special case: related export has been set */
+	return nfs4_export_check_access(req);
+}
+
+void vfs_pnfs_ds_ops_init(struct fsal_pnfs_ds_ops *ops)
+{
+	memcpy(ops, &def_pnfs_ds_ops, sizeof(struct fsal_pnfs_ds_ops));
+	ops->permissions = pds_permissions;
+	ops->make_ds_handle = make_ds_handle;
+	ops->fsal_dsh_ops = dsh_ops_init;
+}

--- a/src/FSAL/FSAL_VFS/vfs/mds.c
+++ b/src/FSAL/FSAL_VFS/vfs/mds.c
@@ -1,0 +1,487 @@
+/*
+ *
+ * vim:noexpandtab:shiftwidth=8:tabstop=8:
+ *
+ * Copyright © 2012 CohortFS, LLC.
+ * Author: Adam C. Emerson <aemerson@linuxbox.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include "gsh_rpc.h"
+#include "fsal.h"
+#include "fsal_types.h"
+#include "fsal_api.h"
+#include "FSAL/access_check.h"
+#include "fsal_convert.h"
+#include "../vfs_methods.h"
+#include <unistd.h>
+#include <fcntl.h>
+#include "FSAL/fsal_commonlib.h"
+
+#include "pnfs_utils.h"
+#include "nfs_exports.h"
+#include "export_mgr.h"
+
+
+/**
+ * @brief Get layout types supported by export
+ *
+ * We just return a pointer to the single type and set the count to 1.
+ *
+ * @param[in]  export_pub Public export handle
+ * @param[out] count      Number of layout types in array
+ * @param[out] types      Static array of layout types that must not be
+ *                        freed or modified and must not be dereferenced
+ *                        after export reference is relinquished
+ */
+
+static void
+vfs_fs_layouttypes(struct fsal_export *export_hdl,
+		      int32_t *count,
+		      const layouttype4 **types)
+{
+	static const layouttype4 supported_layout_type = LAYOUT4_NFSV4_1_FILES;
+
+	/* FSAL_VFS currently supports only LAYOUT4_NFSV4_1_FILES */
+	/** @todo: do a switch that cheks which layout is OK */
+	*types = &supported_layout_type;
+	*count = 1;
+}
+
+/**
+ * @brief Get layout block size for export
+ *
+ * This function just returns the VFS default.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return 4 MB.
+ */
+static uint32_t
+vfs_fs_layout_blocksize(struct fsal_export *export_pub)
+{
+	return 0x400000;
+}
+
+/**
+ * @brief Maximum number of segments we will use
+ *
+ * Since current clients only support 1, that's what we'll use.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return 1
+ */
+static uint32_t
+vfs_fs_maximum_segments(struct fsal_export *export_pub)
+{
+	return 1;
+}
+
+/**
+ * @brief Size of the buffer needed for a loc_body
+ *
+ * Just a handle plus a bit.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return Size of the buffer needed for a loc_body
+ */
+static size_t
+vfs_fs_loc_body_size(struct fsal_export *export_pub)
+{
+	return 0x100;
+}
+
+/**
+ * @brief Size of the buffer needed for a ds_addr
+ *
+ * This one is huge, due to the striping pattern.
+ *
+ * @param[in] export_pub Public export handle
+ *
+ * @return Size of the buffer needed for a ds_addr
+ */
+size_t vfs_fs_da_addr_size(struct fsal_module *fsal_hdl)
+{
+	return 0x1400;
+}
+
+/**
+ * @param[out] da_addr_body Stream we write the result to
+ * @param[in]  type         Type of layout that gave the device
+ * @param[in]  deviceid     The device to look up
+ *
+ * @return Valid error codes in RFC 5661, p. 365.
+ */
+
+
+nfsstat4 vfs_getdeviceinfo(struct fsal_module *fsal_hdl,
+			      XDR *da_addr_body,
+			      const layouttype4 type,
+			      const struct pnfs_deviceid *deviceid)
+{
+	/* The number of DSs  */
+	unsigned num_ds = 0; /** @todo To be set via a call to llapi */
+
+	/* Currently, all layouts have the same number of stripes */
+	uint32_t stripe_count = 0;
+	uint32_t stripe = 0;
+
+	/* NFSv4 status code */
+	nfsstat4 nfs_status = 0;
+	/* ds list iterator */
+	struct glist_head *entry;
+	struct vfs_pnfs_ds_parameter *ds;
+	struct vfs_pnfs_parameter *pnfs_param;
+	struct vfs_fsal_module *vfs_me =
+		container_of(fsal_hdl, struct vfs_fsal_module, fsal);
+
+	/* Sanity check on type */
+	if (type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			type);
+		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+	pnfs_param = &vfs_me->pnfs_param;
+
+	/* Retrieve and calculate storage parameters of layout */
+	stripe_count = glist_length(&pnfs_param->ds_list);
+
+	LogDebug(COMPONENT_PNFS, "device_id %u/%u/%u %lu",
+		 deviceid->device_id1, deviceid->device_id2,
+		 deviceid->device_id4, deviceid->devid);
+
+	if (!inline_xdr_u_int32_t(da_addr_body, &stripe_count)) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode length of stripe_indices array: %"
+			PRIu32 ".",
+			stripe_count);
+		return NFS4ERR_SERVERFAULT;
+	}
+
+	for (stripe = 0; stripe < stripe_count; stripe++) {
+		if (!inline_xdr_u_int32_t(da_addr_body, &stripe)) {
+			LogCrit(COMPONENT_PNFS,
+				"Failed to encode OSD for stripe %u.", stripe);
+			return NFS4ERR_SERVERFAULT;
+		}
+	}
+
+	num_ds = stripe_count; /* aka glist_length(&pnfs_param->ds_list) */
+	if (!inline_xdr_u_int32_t(da_addr_body, &num_ds)) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode length of multipath_ds_list array: %u",
+			num_ds);
+		return NFS4ERR_SERVERFAULT;
+	}
+
+	/* lookup for the right DS in the ds_list */
+	glist_for_each(entry, &pnfs_param->ds_list) {
+		fsal_multipath_member_t host;
+
+		ds = glist_entry(entry,
+				 struct vfs_pnfs_ds_parameter,
+				 ds_list);
+
+		LogDebug(COMPONENT_PNFS,
+			"advertises DS addr=%u.%u.%u.%u port=%u id=%u",
+			(ntohl(ds->ipaddr.sin_addr.s_addr) & 0xFF000000) >> 24,
+			(ntohl(ds->ipaddr.sin_addr.s_addr) & 0x00FF0000) >> 16,
+			(ntohl(ds->ipaddr.sin_addr.s_addr) & 0x0000FF00) >> 8,
+			ntohl(ds->ipaddr.sin_addr.s_addr) & 0x000000FF,
+			ntohs(ds->ipport), ds->id);
+
+		host.proto = IPPROTO_TCP;
+		host.addr = ntohl(ds->ipaddr.sin_addr.s_addr);
+		host.port = ntohs(ds->ipport);
+		nfs_status = FSAL_encode_v4_multipath(
+				da_addr_body,
+				1,
+				&host);
+		if (nfs_status != NFS4_OK)
+			return nfs_status;
+	}
+
+	return NFS4_OK;
+}
+
+/**
+ * @brief Get list of available devices
+ *
+ * We do not support listing devices and just set EOF without doing
+ * anything.
+ *
+ * @param[in]     export_pub Export handle
+ * @param[in]     type      Type of layout to get devices for
+ * @param[in]     cb        Function taking device ID halves
+ * @param[in,out] res       In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, pp. 365-6.
+ */
+
+static nfsstat4
+vfs_getdevicelist(struct fsal_export *export_pub,
+		     layouttype4 type,
+		     void *opaque,
+		     bool (*cb)(void *opaque,
+			const uint64_t id),
+		     struct fsal_getdevicelist_res *res)
+{
+	res->eof = true;
+	return NFS4_OK;
+}
+
+void
+export_ops_pnfs(struct export_ops *ops)
+{
+	ops->getdevicelist = vfs_getdevicelist;
+	ops->fs_layouttypes = vfs_fs_layouttypes;
+	ops->fs_layout_blocksize = vfs_fs_layout_blocksize;
+	ops->fs_maximum_segments = vfs_fs_maximum_segments;
+	ops->fs_loc_body_size = vfs_fs_loc_body_size;
+}
+
+/**
+ * @brief Grant a layout segment.
+ *
+ * Grant a layout on a subset of a file requested.  As a special case,
+ * lie and grant a whole-file layout if requested, because Linux will
+ * ignore it otherwise.
+ *
+ * @param[in]     obj_pub  Public object handle
+ * @param[in]     req_ctx  Request context
+ * @param[out]    loc_body An XDR stream to which the FSAL must encode
+ *                         the layout specific portion of the granted
+ *                         layout segment.
+ * @param[in]     arg      Input arguments of the function
+ * @param[in,out] res      In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, pp. 366-7.
+ */
+
+
+static nfsstat4
+vfs_layoutget(struct fsal_obj_handle *obj_hdl,
+		 struct req_op_context *req_ctx,
+		 XDR *loc_body,
+		 const struct fsal_layoutget_arg *arg,
+		 struct fsal_layoutget_res *res)
+{
+	struct vfs_fsal_obj_handle *myself;
+	struct vfs_exp_pnfs_parameter *pnfs_exp_param;
+	struct vfs_pnfs_parameter *pnfs_param;
+	struct vfs_pnfs_ds_parameter *ds;
+	struct vfs_fsal_export *myexport;
+	struct vfs_file_handle vfs_ds_handle;
+	uint32_t stripe_unit = 0;
+	nfl_util4 util = 0;
+	struct pnfs_deviceid deviceid = DEVICE_ID_INIT_ZERO(FSAL_ID_VFS);
+	nfsstat4 nfs_status = 0;
+	struct gsh_buffdesc ds_desc;
+	struct vfs_fsal_module *vfs_me;
+
+	/* Get pnfs parameters */
+	vfs_me = container_of(obj_hdl->fsal,
+				 struct vfs_fsal_module,
+				 fsal);
+	pnfs_param = &vfs_me->pnfs_param;
+
+	myexport = container_of(req_ctx->fsal_export,
+				struct vfs_fsal_export,
+				export);
+	pnfs_exp_param = &myexport->pnfs_param;
+
+	/* We support only LAYOUT4_NFSV4_1_FILES layouts */
+
+	if (arg->type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->type);
+		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	/* Get basic information on the file and calculate the dimensions
+	 *of the layout we can support. */
+
+	myself = container_of(obj_hdl,
+			      struct vfs_fsal_obj_handle,
+			      obj_handle);
+	memcpy(&vfs_ds_handle,
+	       myself->handle, sizeof(struct vfs_file_handle));
+
+
+	/** @todo: here, put some code to check if such
+	 * a layout is available. If not,
+	 * return NFS4ERR_UNKNOWN_LAYOUTTYPE */
+
+	/* We grant only one segment, and we want
+	 * it back when the file is closed. */
+	res->return_on_close = true;
+	res->last_segment = true;
+	res->segment.offset = 0;
+	res->segment.length = NFS4_UINT64_MAX;
+
+	stripe_unit = pnfs_exp_param->stripe_unit;
+	/* util |= stripe_unit | NFL4_UFLG_COMMIT_THRU_MDS; */
+	util |= stripe_unit & ~NFL4_UFLG_MASK;
+
+	if (util != stripe_unit)
+		LogEvent(COMPONENT_PNFS,
+			 "Invalid stripe_unit %u, truncated to %u",
+			 stripe_unit, util);
+
+	/** @todo: several DSs not handled yet */
+	/* deviceid.devid =  pnfs_param.ds_param[0].id; */
+	ds = glist_first_entry(&pnfs_param->ds_list,
+			       struct vfs_pnfs_ds_parameter,
+			       ds_list);
+	deviceid.devid = ds->id;
+
+	/* last_possible_byte = NFS4_UINT64_MAX; strict. set but unused */
+
+	LogDebug(COMPONENT_PNFS,
+		 "devid nodeAddr %016"PRIx64,
+		 deviceid.devid);
+
+	ds_desc.addr = &vfs_ds_handle;
+	ds_desc.len = sizeof(struct vfs_file_handle);
+
+	nfs_status = FSAL_encode_file_layout(
+			loc_body,
+			&deviceid,
+			util,
+			0,
+			0,
+			&req_ctx->ctx_export->export_id,
+			1,
+			&ds_desc);
+	if (nfs_status) {
+		LogCrit(COMPONENT_PNFS,
+			"Failed to encode nfsv4_1_file_layout.");
+		goto relinquish;
+	}
+
+	return NFS4_OK;
+
+relinquish:
+
+	return nfs_status;
+}
+
+/**
+ * @brief Potentially return one layout segment
+ *
+ * Since we don't make any reservations, in this version, or get any
+ * pins to release, always succeed
+ *
+ * @param[in] obj_pub  Public object handle
+ * @param[in] req_ctx  Request context
+ * @param[in] lrf_body Nothing for us
+ * @param[in] arg      Input arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, p. 367.
+ */
+
+static nfsstat4
+vfs_layoutreturn(struct fsal_obj_handle *obj_hdl,
+		    struct req_op_context *req_ctx,
+		    XDR *lrf_body,
+		    const struct fsal_layoutreturn_arg *arg)
+{
+	struct vfs_fsal_obj_handle *myself;
+	/* The private 'full' object handle */
+	struct vfs_file_handle *vfs_handle __attribute__((unused));
+
+	/* Sanity check on type */
+	if (arg->lo_type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->lo_type);
+	return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	myself = container_of(obj_hdl,
+			      struct vfs_fsal_obj_handle,
+			      obj_handle);
+	vfs_handle = myself->handle;
+
+	return NFS4_OK;
+}
+
+/**
+ * @brief Commit a segment of a layout
+ *
+ * Update the size and time for a file accessed through a layout.
+ *
+ * @param[in]     obj_pub  Public object handle
+ * @param[in]     req_ctx  Request context
+ * @param[in]     lou_body An XDR stream containing the layout
+ *                         type-specific portion of the LAYOUTCOMMIT
+ *                         arguments.
+ * @param[in]     arg      Input arguments of the function
+ * @param[in,out] res      In/out and output arguments of the function
+ *
+ * @return Valid error codes in RFC 5661, p. 366.
+ */
+
+static nfsstat4
+vfs_layoutcommit(struct fsal_obj_handle *obj_hdl,
+		    struct req_op_context *req_ctx,
+		    XDR *lou_body,
+		    const struct fsal_layoutcommit_arg *arg,
+		    struct fsal_layoutcommit_res *res)
+{
+	struct vfs_fsal_obj_handle *myself;
+	/* The private 'full' object handle */
+	struct vfs_file_handle *vfs_handle __attribute__((unused));
+
+	/* Sanity check on type */
+	if (arg->type != LAYOUT4_NFSV4_1_FILES) {
+		LogCrit(COMPONENT_PNFS,
+			"Unsupported layout type: %x",
+			arg->type);
+		return NFS4ERR_UNKNOWN_LAYOUTTYPE;
+	}
+
+	myself =
+		container_of(obj_hdl,
+			     struct vfs_fsal_obj_handle,
+			     obj_handle);
+	vfs_handle = myself->handle;
+
+	/** @todo: here, add code to actually commit the layout */
+	res->size_supplied = false;
+	res->commit_done = true;
+
+	return NFS4_OK;
+}
+
+
+void
+handle_ops_pnfs(struct fsal_obj_ops *ops)
+{
+	ops->layoutget = vfs_layoutget;
+	ops->layoutreturn = vfs_layoutreturn;
+	ops->layoutcommit = vfs_layoutcommit;
+}

--- a/src/FSAL/FSAL_VFS/vfs_methods.h
+++ b/src/FSAL/FSAL_VFS/vfs_methods.h
@@ -39,11 +39,19 @@ struct vfs_filesystem;
 /*
  * VFS internal export
  */
+struct vfs_exp_pnfs_parameter {
+        unsigned int stripe_unit;
+        bool pnfs_enabled;
+};
+
 struct vfs_fsal_export {
 	struct fsal_export export;
 	struct fsal_filesystem *root_fs;
 	struct glist_head filesystems;
 	int fsid_type;
+	bool pnfs_ds_enabled;
+	bool pnfs_mds_enabled;
+	struct vfs_exp_pnfs_parameter pnfs_param;
 };
 
 #define EXPORT_VFS_FROM_FSAL(fsal) \
@@ -68,6 +76,33 @@ struct vfs_filesystem_export_map {
 	struct glist_head on_exports;
 	struct glist_head on_filesystems;
 };
+
+/* pNFS types. */
+struct vfs_ds {
+	struct fsal_ds_handle ds; /*< Public DS handle */
+	vfs_file_handle_t wire; /*< Wire data */
+	struct vfs_filesystem *vfs_fs; /*< Related Vfs filesystem */
+	bool connected; /*< True if the handle has been connected */
+};
+
+/* this needs to be refactored to put ipport inside sockaddr_in */
+struct vfs_pnfs_ds_parameter {
+        struct glist_head ds_list;
+        struct sockaddr_in ipaddr;
+        unsigned short ipport;
+        unsigned int id;
+};
+
+struct vfs_pnfs_parameter {
+        struct glist_head ds_list;
+};
+
+struct vfs_fsal_module {
+        struct fsal_module fsal;
+        struct fsal_staticfsinfo_t fs_info;
+        struct vfs_pnfs_parameter pnfs_param;
+};
+
 
 void vfs_unexport_filesystems(struct vfs_fsal_export *exp);
 


### PR DESCRIPTION
Hi, 

this PR is just to get some feedback, whether I am on track - and how to test things... 

As shortly discussed on IRC, I looked into the old FSAL_LUSTRE code and extracted the bits (hopefully all) necessary for MDS / DS => pNFS support. 
As noted there, this is meant to support the case of a mounted shared filesystem (e.g. Lustre, BeeGFS) on several data servers to increase bandwidth via pNFS. 

I got things to compile by adapting to some renamings of struct members in the codebase, in once case rewriting something Lustre-specific to use vfs_open instead, and finally, of course, by sed'ing Lustre to VFS ;-). 

I did not yet do any functional test - is there a test suite available in some way, or do you have some test setup for development? 
Could somebody have a look and tell me whether something is blatantly wrong? 
