### PR TITLE
NLM: Validate state pointer  in function nlm_process_parameters

### DIFF
--- a/src/Protocols/NLM/nlm_util.c
+++ b/src/Protocols/NLM/nlm_util.c
@@ -335,7 +335,7 @@ int nlm_process_parameters(struct svc_req *req, bool exclusive,
 				   nsm_state,
 				   state);
 
-		if (rc > 0) {
+		if (rc > 0 || !(*state)) {
 			LogDebug(COMPONENT_NLM, "Could not get NLM State");
 			goto out_put;
 		}


### PR DESCRIPTION
same as change-id: Id6269aee36bcf52d0a0258d68c401bbfb9b7bc77， but in function nlm_process_parameters. get_nlm_state() can return NULL state pointer if not found in hash table.