### PR TITLE
fsal_rgw: support directory object as an export

### DIFF
--- a/src/FSAL/FSAL_RGW/export.c
+++ b/src/FSAL/FSAL_RGW/export.c
@@ -103,34 +103,65 @@ static fsal_status_t lookup_path(struct fsal_export *export_pub,
 	int rc;
 	/* temp filehandle */
 	struct rgw_file_handle *rgw_fh;
+	/* bucket name */
+	const char* bucket_name = NULL;
+	/* global directory */
+	const char* global_dir = NULL;
 
 	*pub_handle = NULL;
 
-	/* should only be "/" or "bucket_name" */
-	if (strcmp(path, "/") && strchr(path, '/')) {
-		status.major = ERR_FSAL_INVAL;
+	/* pattern like "bucket_name/" or "bucket_name/dir/" should be avoid */
+	if(strcmp(path, "/") && !strcmp((path + strlen(path) - 1), "/")) {
+			status.major = ERR_FSAL_INVAL;
 		return status;
 	}
 
-#ifndef USE_FSAL_RGW_MOUNT2
 	/* XXX in FSAL_CEPH, the equivalent code here looks for path == "/"
 	 * and returns the root handle with no extra ref.  That seems
 	 * suspicious, so let RGW figure it out (hopefully, that does not
 	 * leak refs)
 	 */
-	rc = rgw_lookup(export->rgw_fs, export->rgw_fs->root_fh, path,
-			&rgw_fh, RGW_LOOKUP_FLAG_NONE);
-	if (rc < 0)
-		return rgw2fsal_error(rc);
+	if(global_dir == NULL) {
+#ifndef USE_FSAL_RGW_MOUNT2
+		rc = rgw_lookup(export->rgw_fs, export->rgw_fs->root_fh, path,
+         &rgw_fh, RGW_LOOKUP_FLAG_NONE);
+		if (rc < 0)
+    	return rgw2fsal_error(rc);
 #else
-	rgw_fh = export->rgw_fs->root_fh;
+		rgw_fh = export->rgw_fs->root_fh;
 #endif
+	} else {
+		/* search fh of bucket */
+		struct rgw_file_handle *rgw_dh;
+		rc = rgw_lookup(export->rgw_fs, export->rgw_fs->root_fh, bucket_name,
+		     &rgw_dh, RGW_LOOKUP_FLAG_NONE);
+		if (rc < 0)
+			return rgw2fsal_error(rc);
+		/* search fh of global directory */
+		rc = rgw_lookup(export->rgw_fs, rgw_dh, global_dir,
+		     &rgw_fh, RGW_LOOKUP_FLAG_RCB);
+		if (rc < 0)
+			return rgw2fsal_error(rc);
+		if (rgw_fh->fh_type == RGW_FS_TYPE_FILE) {
+		  /* only directory can be an global fh */
+			status.major = ERR_FSAL_INVAL;
+			return status;
+    }
+  }
 
 	/* get Unix attrs */
-	rc = rgw_getattr(export->rgw_fs, export->rgw_fs->root_fh,
-			 &st, RGW_GETATTR_FLAG_NONE);
-	if (rc < 0) {
-		return rgw2fsal_error(rc);
+	if(global_dir == NULL) {
+		rc = rgw_getattr(export->rgw_fs, export->rgw_fs->root_fh,
+		     &st, RGW_GETATTR_FLAG_NONE);
+		if (rc < 0) {
+		  return rgw2fsal_error(rc);
+		}
+	} else {
+  	rc = rgw_getattr(export->rgw_fs, rgw_fh, &st,
+         RGW_GETATTR_FLAG_NONE);
+		if (rc < 0) {
+    	return rgw2fsal_error(rc);
+		}
 	}
 
 #ifndef USE_FSAL_RGW_MOUNT2

--- a/src/FSAL/FSAL_RGW/main.c
+++ b/src/FSAL/FSAL_RGW/main.c
@@ -289,13 +289,30 @@ static fsal_status_t create_export(struct fsal_module *module_in,
 			       &export->rgw_fs,
 			       RGW_MOUNT_FLAG_NONE);
 #else
-	rgw_status = rgw_mount2(RGWFSM.rgw,
-				export->rgw_user_id,
-				export->rgw_access_key_id,
-				export->rgw_secret_access_key,
-				op_ctx->ctx_export->fullpath,
-				&export->rgw_fs,
-				RGW_MOUNT_FLAG_NONE);
+	const char *fullpath = op_ctx->ctx_export->fullpath;
+	if(strcmp(fullpath, "/") && strchr(fullpath, '/') &&
+  		(strchr(fullpath, '/') - fullpath) > 1) {
+  	/* case : "bucket_name/dir" */
+		rgw_status = rgw_mount(RGWFSM.rgw,
+					export->rgw_user_id,
+					export->rgw_access_key_id,
+					export->rgw_secret_access_key,
+					&export->rgw_fs,
+					RGW_MOUNT_FLAG_NONE);
+	} else {
+		/* case : "/" of "bucket_name" or "/bucket_name" */
+		if(strcmp(fullpath, "/") && strchr(fullpath, '/') &&
+    		(strchr(fullpath, '/') - fullpath) == 0) {
+			fullpath = op_ctx->ctx_export->fullpath + 1;
+		}
+		rgw_status = rgw_mount2(RGWFSM.rgw,
+					export->rgw_user_id,
+					export->rgw_access_key_id,
+					export->rgw_secret_access_key,
+					fullpath,
+					&export->rgw_fs,
+					RGW_MOUNT_FLAG_NONE);
+	}
 #endif
 	if (rgw_status != 0) {
 		status.major = ERR_FSAL_SERVERFAULT;


### PR DESCRIPTION
Signed-off-by: Tao CHEN <chentao@umcloud.com>

FSAL RGW currently only support "/" or "bucket" as an export, I think we can also make a directory under a bucket as an export too, like:
```shell
EXPORT
{
  Export_ID=1;
  Path = "bucket1/dir1";
  Pseudo = "/";
  Access_Type = RW;
  Protocols = 4;
  Squash = No_Root_Squash;
  Transports = TCP;
  ...
}

``` 
The reason that I made this is, that I found if there is a huge number of objects inside a bucket(like millions),  the "ls" operation to mount point will extremely  slow because Ceph Rados will parse all objects under this bucket, which is unnecessary. So if it is possible to make a directory under a bucket as an export,  we could divide a bucket into several directory, which will surely reduce "ls" operation cost.

Thanks for your attention!