### PR TITLE
FIX #162 - Fix systemd service reload

### DIFF
--- a/src/scripts/systemd/nfs-ganesha.service.debian8
+++ b/src/scripts/systemd/nfs-ganesha.service.debian8
@@ -27,7 +27,7 @@ EnvironmentFile=-/etc/default/nfs-ganesha
 ExecStart=/bin/bash -c "${NUMACTL} ${NUMAOPTS} /usr/bin/ganesha.nfsd ${OPTIONS} ${EPOCH}"
 ExecStartPost=-/bin/bash -c "prlimit --pid $MAINPID --nofile=$NOFILE:$NOFILE"
 ExecStartPost=-/bin/bash -c "/bin/sleep 2 && /usr/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin  org.ganesha.nfsd.admin.init_fds_limit"
-ExecReload=/usr/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin  org.ganesha.nfsd.admin.reload
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/usr/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin org.ganesha.nfsd.admin.shutdown
 
 [Install]

--- a/src/scripts/systemd/nfs-ganesha.service.el7
+++ b/src/scripts/systemd/nfs-ganesha.service.el7
@@ -27,7 +27,7 @@ EnvironmentFile=-/run/sysconfig/ganesha
 ExecStart=/bin/bash -c "${NUMACTL} ${NUMAOPTS} /usr/bin/ganesha.nfsd ${OPTIONS} ${EPOCH}"
 ExecStartPost=-/bin/bash -c "prlimit --pid $MAINPID --nofile=$NOFILE:$NOFILE"
 ExecStartPost=-/bin/bash -c "/usr/bin/sleep 2 && /bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin  org.ganesha.nfsd.admin.init_fds_limit"
-ExecReload=/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin  org.ganesha.nfsd.admin.reload
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/dbus-send --system   --dest=org.ganesha.nfsd --type=method_call /org/ganesha/nfsd/admin org.ganesha.nfsd.admin.shutdown
 
 [Install]


### PR DESCRIPTION
The `org.ganesha.nfsd.admin.reload` dbus method as been removed by https://github.com/nfs-ganesha/nfs-ganesha/commit/5cd4abd6c738bb88ed80793ab2734902e270f25c 

The correct way to reload the service is to send a SIGHUP to the main process.