### PR TITLE
FSAL_VFS: fix fd_lock release bug in function vfs_read2

### DIFF
--- a/src/FSAL/FSAL_VFS/file.c
+++ b/src/FSAL/FSAL_VFS/file.c
@@ -1202,7 +1202,10 @@ fsal_status_t vfs_read2(struct fsal_obj_handle *obj_hdl,
 
  out:
 
-	if (closefd) {
+	if (vfs_fd)
+		PTHREAD_RWLOCK_unlock(&vfs_fd->fdlock);
+	
+        if (closefd) {
 		LogFullDebug(COMPONENT_FSAL, "Closing Opened fd %d", my_fd);
 		close(my_fd);
 	}


### PR DESCRIPTION
linux test project test case(include ltp-fs-rwtest01, ltp-fs-iogen01 ) will not pass, 
if don't unlock(fd_lock) in vfs_read2 in vfs_read2.