### PR TITLE
remove improper SVC_DESTROY

### DIFF
--- a/src/MainNFSD/nfs_worker_thread.c
+++ b/src/MainNFSD/nfs_worker_thread.c
@@ -1400,7 +1400,6 @@ static enum xprt_stat nfs_rpc_process_request(request_data_t *reqdata)
 				 reqdata->r_u.req.svc.rq_msg.cb_vers,
 				 reqdata->r_u.req.svc.rq_msg.cb_proc,
 				 errno);
-			SVC_DESTROY(xprt);
 			goto freeargs;
 		}
 


### PR DESCRIPTION
destroy xprt here will cause random crash in SVC_STAT(xprt) later
this is because the xprt is already freed and its xp_ops struct
cannot be used
valgrind will report many uninitialized read for the same reason

after this fix, uninitialized read is not reported any more
no mem leak will happen as the xprt will still be freed in free_nfs_request

Signed-off-by: Stuart Hu <hushijie@qiniu.com>