### PR TITLE
Add explicit CheckSymbolExists include

### DIFF
--- a/src/cmake/modules/FindCEPHFS.cmake
+++ b/src/cmake/modules/FindCEPHFS.cmake
@@ -127,6 +127,7 @@ else (NOT CEPH_FS)
   endif(NOT CEPH_FS_GET_FS_CID)
 
   set(CMAKE_REQUIRED_INCLUDES ${CEPHFS_INCLUDE_DIR})
+  include(CheckSymbolExists)
   check_symbol_exists(CEPH_STATX_INO "cephfs/libcephfs.h" CEPH_FS_CEPH_STATX)
   if(NOT CEPH_FS_CEPH_STATX)
     message("Cannot find CEPH_STATX_INO. Enabling backward compatibility for pre-ceph_statx APIs.")


### PR DESCRIPTION
Builds with current cmake fails as the check_symbols_exists command is
not a built-in and no longer included implicitly.

Fixes #454.