### PR TITLE
fix nfs client IO hang during heavy workload

### DIFF
--- a/src/MainNFSD/nfs_worker_thread.c
+++ b/src/MainNFSD/nfs_worker_thread.c
@@ -1053,16 +1053,6 @@ static enum xprt_stat nfs_rpc_process_request(nfs_request_t *reqdata)
 			}
 			break;
 
-			/* Another thread owns the request */
-		case DUPREQ_BEING_PROCESSED:
-			LogFullDebug(COMPONENT_DISPATCH,
-				     "DUP: Request xid=%" PRIu32
-				     " is already being processed; the active thread will reply",
-				     reqdata->svc.rq_msg.rm_xid);
-			/* Free the arguments */
-			/* Ignore the request, send no error */
-			break;
-
 		default:
 			LogCrit(COMPONENT_DISPATCH,
 				"DUP: Unknown duplicate request cache status. This should never be reached!");

--- a/src/include/nfs_dupreq.h
+++ b/src/include/nfs_dupreq.h
@@ -99,6 +99,7 @@ struct dupreq_entry {
 	dupreq_state_t state;
 	uint32_t refcnt;
 	nfs_res_t *res;
+	bool wait_processing;
 };
 
 typedef struct dupreq_entry dupreq_entry_t;
@@ -117,7 +118,6 @@ static inline void free_nfs_res(nfs_res_t *res)
 
 typedef enum dupreq_status {
 	DUPREQ_SUCCESS = 0,
-	DUPREQ_BEING_PROCESSED,
 	DUPREQ_EXISTS,
 } dupreq_status_t;
 


### PR DESCRIPTION
the hang was introduced in the following case:
  1. nfs client send IO-1 to the nfs ganesha, where it first goes
     into the drc and makerd DUPREQ_START.
  2. the IO-1 stucked and being processed very slow in the ganesha
     server due to heavy io workload and unfortunately, the nfs client
     and ganesha server experienced network timedout and nfs client
     issued reconnect then retry IO-1
  3. the step-2's retry IO-1 enters into the ganesha drc and found
     the same xid request is BEING_PROCESSED, so it will do nothing
     and directly returned under the assumption that after step-1 's
     IO-1 completed, it will reply to the nfs client.
  4. after step-1 's IO-1 completion, when trying to reply the client,
     it found the XPRT_DESTROYED due to the previous nfs client reconnect,
     and the reply will be dropped.

Finally, the nfs client will forever hang and ganesha server will never
reply the IO.