### PR TITLE
spec: remove %{_defaultdocdir}/ganesha directory

### DIFF
--- a/src/nfs-ganesha.spec-in.cmake
+++ b/src/nfs-ganesha.spec-in.cmake
@@ -668,8 +668,6 @@ exit 0
 %config(noreplace) %{_sysconfdir}/logrotate.d/ganesha
 %dir %{_sysconfdir}/ganesha/
 %config(noreplace) %{_sysconfdir}/ganesha/ganesha.conf
-%dir %{_defaultdocdir}/ganesha/
-%{_defaultdocdir}/ganesha/*
 %dir %{_localstatedir}/run/ganesha
 %dir %{_libexecdir}/ganesha
 %{_libexecdir}/ganesha/nfs-ganesha-config.sh


### PR DESCRIPTION
We have:

```
%dir %{_defaultdocdir}/ganesha/
%{_defaultdocdir}/ganesha/*
```

But nothing is created in %{_defaultdocdir}/ganesha during the build so
the rpm build is failing.

```console
Directory not found: BUILDROOT/nfs-ganesha-4-dev.31.el8.x86_64/usr/share/doc/ganesha
File not found: BUILDROOT/nfs-ganesha-4-dev.31.el8.x86_64/usr/share/doc/ganesha/*
```

Closes: #631

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>