### PR TITLE
docs: fix simple typo, repsonse -> response

### DIFF
--- a/src/FSAL/FSAL_GPFS/include/gpfs_nfs.h
+++ b/src/FSAL/FSAL_GPFS/include/gpfs_nfs.h
@@ -369,8 +369,8 @@ struct pnfstime4 {
 };
 
 struct nfsd4_pnfs_dev_iter_res {
-	uint64_t		gd_cookie;	/* request/repsonse */
-	uint64_t		gd_verf;	/* request/repsonse */
+	uint64_t		gd_cookie;	/* request/response */
+	uint64_t		gd_verf;	/* request/response */
 	uint64_t		gd_devid;	/* response */
 	uint32_t		gd_eof;		/* response */
 };


### PR DESCRIPTION
There is a small typo in src/FSAL/FSAL_GPFS/include/gpfs_nfs.h.

Should read `response` rather than `repsonse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md