### PR TITLE
Replace ${CMAKE_SOURCE_DIR} into ${CMAKE_CURRENT_SOURCE_DIR}.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ if( "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER "2.6" )
   endif(COMMAND cmake_policy)
 endif( "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER "2.6" )
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 
 project(nfs-ganesha C CXX)
 # Project versioning
@@ -127,37 +127,37 @@ find_package(Toolchain REQUIRED)
 find_package(Sanitizers)
 
 # Add maintainer mode for (mainly) strict builds
-include(${CMAKE_SOURCE_DIR}/cmake/maintainer_mode.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/maintainer_mode.cmake)
 
 # For libraries that provide pkg-config files
 include(FindPkgConfig)
 
 # For our option system
-include(${CMAKE_SOURCE_DIR}/cmake/goption.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/goption.cmake)
 
 # If we are in a git tree, then this CMakeLists.txt is in "src/" and go .git is in "src/.."
-IF( EXISTS ${CMAKE_SOURCE_DIR}/../.git/HEAD  )
+IF( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.git/HEAD  )
   message( STATUS "Compilation from within a git repository. Using git rev-parse HEAD")
   EXECUTE_PROCESS( COMMAND git rev-parse HEAD
-		   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		   OUTPUT_STRIP_TRAILING_WHITESPACE
 		   ERROR_QUIET
                    OUTPUT_VARIABLE _GIT_HEAD_COMMIT)
   EXECUTE_PROCESS( COMMAND git describe --long
-                   WORKING_DIRECTORY  ${CMAKE_SOURCE_DIR}
+                   WORKING_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}
 		   OUTPUT_STRIP_TRAILING_WHITESPACE
 		   ERROR_QUIET
                    OUTPUT_VARIABLE _GIT_DESCRIBE)
 
-ELSE( EXISTS ${CMAKE_SOURCE_DIR}/../.git/HEAD  )
+ELSE( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.git/HEAD  )
   message( STATUS "Outside a git repository, use saved data" )
-  EXEC_PROGRAM(${CMAKE_SOURCE_DIR}/cmake/githead_from_path.sh ARGS ${CMAKE_SOURCE_DIR}
+  EXEC_PROGRAM(${CMAKE_CURRENT_SOURCE_DIR}/cmake/githead_from_path.sh ARGS ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_VARIABLE  _GIT_HEAD_COMMIT)
 
-  EXEC_PROGRAM(${CMAKE_SOURCE_DIR}/cmake/gitdesc_from_path.sh ARGS ${CMAKE_SOURCE_DIR}
+  EXEC_PROGRAM(${CMAKE_CURRENT_SOURCE_DIR}/cmake/gitdesc_from_path.sh ARGS ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_VARIABLE  _GIT_DESCRIBE)
 
-ENDIF( EXISTS ${CMAKE_SOURCE_DIR}/../.git/HEAD  )
+ENDIF( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../.git/HEAD  )
 
 STRING(SUBSTRING ${_GIT_HEAD_COMMIT} 0  7 _GIT_HEAD_COMMIT_ABBREV )
 
@@ -287,7 +287,7 @@ else(USE_SYSTEM_NTIRPC)
 endif(USE_SYSTEM_NTIRPC)
 
 # Include custom config and cpack module
-include(${CMAKE_SOURCE_DIR}/cmake/cpack_config.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_config.cmake)
 include(CPack)
 
 # MSPAC support -lwbclient link flag
@@ -410,7 +410,7 @@ option(USE_ACL_MAPPING "Build NFSv4 to POSIX ACL mapping" OFF)
 
 IF(BUILD_CONFIG)
   INCLUDE(
-  ${CMAKE_SOURCE_DIR}/cmake/build_configurations/${BUILD_CONFIG}.cmake)
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_configurations/${BUILD_CONFIG}.cmake)
 ENDIF()
 
 IF(DEBUG_SYMS)
@@ -1099,7 +1099,7 @@ else (USE_SYSTEM_NTIRPC)
   set(TIRPC_EPOLL ${TIRPC_EPOLL} CACHE BOOL "Use EPOLL")
   set(USE_GSS ${USE_GSS} CACHE BOOL "Use GSS")
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
-	  "${CMAKE_SOURCE_DIR}/libntirpc/cmake/modules/")
+	  "${CMAKE_CURRENT_SOURCE_DIR}/libntirpc/cmake/modules/")
   add_subdirectory(libntirpc)
   set(NTIRPC_LIBRARY ntirpc)
   if (USE_LTTNG)
@@ -1132,8 +1132,8 @@ set(SYSTEM_LIBRARIES
 )
 
 # Config file; make sure it doesn't clobber an existing one
-include(${CMAKE_SOURCE_DIR}/cmake/modules/InstallPackageConfigFile.cmake)
-InstallPackageConfigFile(${CMAKE_SOURCE_DIR}/config_samples/ganesha.conf.example ${SYSCONFDIR}/ganesha ganesha.conf)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/InstallPackageConfigFile.cmake)
+InstallPackageConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/config_samples/ganesha.conf.example ${SYSCONFDIR}/ganesha ganesha.conf)
 # pre-create PREFIX/var/run/ganesha
 install(DIRECTORY DESTINATION ${SYSSTATEDIR}/run/ganesha)
 

--- a/src/MainNFSD/CMakeLists.txt
+++ b/src/MainNFSD/CMakeLists.txt
@@ -169,9 +169,9 @@ if(USE_9P_RDMA)
 endif(USE_9P_RDMA)
 
 if(SANITIZE_ADDRESS)
-	set_target_properties(ganesha_nfsd PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/MainNFSD/libganesha_nfsd.ver")
+	set_target_properties(ganesha_nfsd PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/MainNFSD/libganesha_nfsd.ver")
 else(SANITIZE_ADDRESS)
-	set_target_properties(ganesha_nfsd PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/MainNFSD/libganesha_nfsd.ver -Wl,--no-undefined")
+	set_target_properties(ganesha_nfsd PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/MainNFSD/libganesha_nfsd.ver -Wl,--no-undefined")
 endif(SANITIZE_ADDRESS)
 
 set_target_properties(ganesha_nfsd PROPERTIES

--- a/src/cmake/modules/GetGitRevisionDescription.cmake
+++ b/src/cmake/modules/GetGitRevisionDescription.cmake
@@ -40,7 +40,7 @@ set(__get_git_revision_description YES)
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
 function(get_git_head_revision _refspecvar _hashvar)
-	set(GIT_PARENT_DIR "${CMAKE_SOURCE_DIR}")
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
 	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
 		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
@@ -98,7 +98,7 @@ function(git_describe _var)
 	#message(STATUS "Arguments to execute_process: ${ARGN}")
 
 	execute_process(COMMAND "${GIT_EXECUTABLE}" describe ${hash} ${ARGN}
-		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		RESULT_VARIABLE res
 		OUTPUT_VARIABLE out
 		ERROR_QUIET

--- a/src/cmake/portability_cmake_2.8/FindBISON.cmake
+++ b/src/cmake/portability_cmake_2.8/FindBISON.cmake
@@ -94,7 +94,7 @@ if(BISON_EXECUTABLE)
       DEPENDS
       "${BISON_TARGET_output_path}/${BISON_TARGET_output_name}.output"
       COMMENT "[BISON][${Name}] Copying bison verbose table to ${filename}"
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set(BISON_${Name}_VERBOSE_FILE ${filename})
     list(APPEND BISON_TARGET_extraoutputs
       "${BISON_TARGET_output_path}/${BISON_TARGET_output_name}.output")


### PR DESCRIPTION
If we want to integrate nfs-ganesha into a larger CMake project,
we usually use "add_subdirectory(nfs-ganesha/src)" in the top level
CMakeLists.txt to achive this goal. But the CMakeLists.txt in
nfs-ganesha use predefined variable ${CMAKE_SOURCE_DIR}, this variable
always point to the top level CMakeLists.txt file path, so the cmake
can not work in this case. CMake provides another variable
${CMAKE_CURRENT_SOURCE_DIR}, which stands for the current CMakeLists.txt
file path. I think we should use this variable instead.

Signed-off-by: Gao Mingfei <mingfei.gao@ucloud.cn>
Change-Id: Icd142c57ff7421e70d5370cb9382ddc27c9edc28