### PR TITLE
Add byteswap.h includes in FSAL modules.

### DIFF
--- a/src/FSAL/FSAL_MEM/mem_export.c
+++ b/src/FSAL/FSAL_MEM/mem_export.c
@@ -30,6 +30,7 @@
 #include "config.h"
 
 #include "fsal.h"
+#include <byteswap.h>           /* used for 'bswap*' */
 #include <libgen.h>		/* used for 'dirname' */
 #include <pthread.h>
 #include <string.h>

--- a/src/FSAL/FSAL_PSEUDO/export.c
+++ b/src/FSAL/FSAL_PSEUDO/export.c
@@ -33,6 +33,7 @@
 #include "config.h"
 
 #include "fsal.h"
+#include <byteswap.h>           /* used for 'bswap*' */
 #include <libgen.h>		/* used for 'dirname' */
 #include <pthread.h>
 #include <string.h>


### PR DESCRIPTION
Not sure what the process is for contributing, but as I was trying to compile these the other day I found a couple of failures due to missing includes for the `byteswap.h` header in two of the FSAL modules. This adds that include.