### PR TITLE
Fix cmake variable for Proxy v4 FSAL module.

### DIFF
--- a/src/FSAL/FSAL_PROXY_V4/CMakeLists.txt
+++ b/src/FSAL/FSAL_PROXY_V4/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(fsalproxy_v4_LIB_SRCS
 
 if(PROXYV4_HANDLE_MAPPING)
   SET(fsalproxy_v4_LIB_SRCS
-    ${fsalproxy_LIB_SRCS}
+    ${fsalproxy_v4_LIB_SRCS}
     handle_mapping/handle_mapping.c
     handle_mapping/handle_mapping_db.c
     )


### PR DESCRIPTION
Fixes an issue in the `CMakeLists.txt` file for the Proxy v4 module to include all files correctly.