### PR TITLE
Allow UDP_Enable = false when IPv6 is disabled

### DIFF
--- a/src/support/server_stats.c
+++ b/src/support/server_stats.c
@@ -246,10 +246,12 @@ enum proto_op_type {
 	LAYOUT_OP
 };
 
+#ifdef _USE_NFS3
 static const uint32_t nfsv3_optype[NFS_V3_NB_COMMAND] = {
 	[NFSPROC3_READ] = READ_OP,
 	[NFSPROC3_WRITE] = WRITE_OP,
 };
+#endif
 
 static const uint32_t nfsv40_optype[NFS_V40_NB_OPERATION] = {
 	[NFS4_OP_READ] = READ_OP,


### PR DESCRIPTION
When trying to execute ganesha.nfsd without UDP (`Enable_UDP = false`) on a host who has ipv6 disabled, it fails to start due to a bug in `src/MainNFSD/nfs_rpc_dispatcher_thread.c`.

Moreover, there is an error when compiling in Debug mode with `NFSv3` switched off., because of an unused const `nfsv3_optype` .