### PR TITLE
selinux: Use interfaces calls instead of allow rules

### DIFF
--- a/src/selinux/ganesha.if
+++ b/src/selinux/ganesha.if
@@ -144,3 +144,67 @@ interface(`ganesha_admin',`
 		systemd_read_fifo_file_passwd_run($1)
 	')
 ')
+
+#######################################
+## <summary>
+##      Send and receive messages from glusterd over dbus.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+ifndef(`glusterd_dbus_chat',`
+	interface(`glusterd_dbus_chat',`
+		gen_require(`
+			type glusterd_t;
+		')
+
+		allow $1 glusterd_t:dbus send_msg;
+		allow glusterd_t $1:dbus send_msg;
+	')
+')
+
+#######################################
+## <summary>
+##	Allow glusterd get a service status
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+ifndef(`glusterd_service_status',`
+	interface(`glusterd_service_status',`
+		gen_require(`
+			type glusterd_t;
+		')
+
+		allow glusterd_t $1:service status;
+	')
+')
+
+#######################################
+## <summary>
+##	Allow glusterd start and stop a service
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+ifndef(`glusterd_service_start_stop',`
+	interface(`glusterd_service_start_stop',`
+		gen_require(`
+			type glusterd_t;
+		')
+
+		allow glusterd_t $1:service { start stop };
+	')
+')

--- a/src/selinux/ganesha.te
+++ b/src/selinux/ganesha.te
@@ -52,8 +52,6 @@ require {
 
 	type cluster_t;
 
-	type glusterd_t;
-
 	type ceph_t;
 	type ceph_log_t;
 
@@ -290,15 +288,6 @@ allow rpcbind_t unreserved_port_t:udp_socket name_bind;
 
 ########################################
 #
-# ganesha local policy rhbz#1816501, rhbz#1822500, rhbz#1826101,
-# rhbz#1826627
-
-allow glusterd_t ganesha_unit_file_t:service { start status stop };
-allow glusterd_t ganesha_t:dbus send_msg;
-allow ganesha_t glusterd_t:dbus send_msg;
-
-########################################
-#
 # ganesha local policy rhbz#1857170
 
 allow ganesha_t portmap_port_t:tcp_socket name_connect;
@@ -346,3 +335,15 @@ ifdef(`ceph_read_pid_files',`
 
 allow ganesha_t cluster_t:dbus send_msg;
 allow init_t var_lib_nfs_t:lnk_file read;
+
+########################################
+#
+# ganesha local policy rhbz#1816501, rhbz#1822500, rhbz#1826101,
+# rhbz#1826627
+
+optional_policy(`
+	glusterd_dbus_chat(ganesha_t)
+
+	glusterd_service_status(ganesha_t)
+	glusterd_service_start_stop(ganesha_t)
+')


### PR DESCRIPTION
Using interfaces calls in optional() block is necessary when
a type from a different module is required.

This change is needed for the nfs-ganesha policy to work on systems
where the glusterd module is not currently installed.