### PR TITLE
selinux: Use interface calls instead of allow rules

### DIFF
--- a/src/selinux/ganesha.if
+++ b/src/selinux/ganesha.if
@@ -144,3 +144,64 @@ interface(`ganesha_admin',`
 		systemd_read_fifo_file_passwd_run($1)
 	')
 ')
+
+#######################################
+## <summary>
+##	Start or stop ganesha service
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+interface(`ganesha_service_start_stop',`
+	gen_require(`
+		type ganesha_unit_file_t;
+	')
+
+	allow $1 ganesha_unit_file_t:service { start stop };
+')
+
+#######################################
+## <summary>
+##	Get status of ganesha service
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+
+interface(`ganesha_service_status',`
+	gen_require(`
+		type ganesha_unit_file_t;
+	')
+
+	allow $1 ganesha_unit_file_t:service status;
+')
+
+#######################################
+## <summary>
+##	Send and receive messages from glusterd over dbus.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+#
+# Definition ensuring compatibility with systems that do not have this interface
+ifndef(`glusterd_dbus_chat',`
+	interface(`glusterd_dbus_chat',`
+		gen_require(`
+			type glusterd_t;
+		')
+
+		allow $1 glusterd_t:dbus send_msg;
+		allow glusterd_t $1:dbus send_msg;
+	')
+')

--- a/src/selinux/ganesha.te
+++ b/src/selinux/ganesha.te
@@ -1,8 +1,6 @@
 policy_module(ganesha, 1.0.0)
 
 require {
-	type glusterd_t;
-
 	type var_lib_nfs_t;
 	type apm_bios_t;
 	type autofs_device_t;
@@ -19,8 +17,6 @@ require {
 	type fixed_disk_device_t;
 	type framebuf_device_t;
 	type fs_t;
-	type gluster_port_t;
-	type glusterd_brick_t;
 	type hugetlbfs_t;
 	type initctl_t;
 	type kmsg_device_t;
@@ -288,15 +284,6 @@ allow rpcbind_t unreserved_port_t:udp_socket name_bind;
 
 ########################################
 #
-# ganesha local policy rhbz#1816501, rhbz#1822500, rhbz#1826101,
-# rhbz#1826627
-
-allow glusterd_t ganesha_unit_file_t:service { start status stop };
-allow glusterd_t ganesha_t:dbus send_msg;
-allow ganesha_t glusterd_t:dbus send_msg;
-
-########################################
-#
 # ganesha local policy rhbz#1857170
 
 allow ganesha_t portmap_port_t:tcp_socket name_connect;
@@ -313,6 +300,7 @@ allow ganesha_t self:capability { fowner setgid setuid };
 # if you want to export old gluster brick dirs directly, e.g. because
 # maybe you're no longer using gluster. selinux knows about gluster brick
 # volumes in /bricks/...
+# Needs to be used in an optional_policy block requiring type glusterd_brick_t
 # allow ganesha_t glusterd_brick_t:dir { add_name getattr open read write remove_name search };
 # allow ganesha_t glusterd_brick_t:file { create getattr open read write unlink };
 
@@ -324,4 +312,18 @@ ifdef(`ceph_read_lib_files',`
        optional_policy(`
                ceph_read_lib_files(ganesha_t)
        ')
+')
+
+########################################
+#
+# ganesha local policy rhbz#1816501, rhbz#1822500, rhbz#1826101,
+# rhbz#1826627
+
+optional_policy(`
+	glusterd_dbus_chat(ganesha_t)
+
+	# the following interfaces can only be safely used together with an interface
+	# requiring glusterd_t type such as glusterd_dbus_chat
+	ganesha_service_status(glusterd_t)
+	ganesha_service_start_stop(glusterd_t)
 ')


### PR DESCRIPTION
Using interfaces calls in optional_policy() block is necessary when
a type from a different module is used.

This change is needed for the nfs-ganesha policy to work on systems
where the glusterd module is not currently installed.