### PR TITLE
Fix typos in the documentation

### DIFF
--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -1651,7 +1651,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/src/KNOWN_BUGS
+++ b/src/KNOWN_BUGS
@@ -5,6 +5,6 @@ This file references the known bugs (some of them are under investigation)
 ------------------
 Fixed bug 
 
-  - A deadlock may occur inbetween workers and tcp dispatchers in case of important traffic (fixed in 0.99.46)
+  - A deadlock may occur in between workers and tcp dispatchers in case of important traffic (fixed in 0.99.46)
 
  

--- a/src/README.new_api
+++ b/src/README.new_api
@@ -115,7 +115,7 @@ FSAL
 
 The "FSAL" block has one sub-block, in this example "VFS", for each
 fsal it is to load.  There can be as many sub-blocks as make sense.
-This is the power of trhe new api, to support multiple fsals simultaneously.
+This is the power of the new api, to support multiple fsals simultaneously.
 There is also provision for FSAL global parameters although none are
 actually defined at this point.
 

--- a/src/doc/Resources.txt
+++ b/src/doc/Resources.txt
@@ -21,7 +21,7 @@ Here is a list of things that may be useful with Ganesha.
    http://www.citi.umich.edu/projects/nfsv4/linux/librpcsecgss/
 
  * locktests-net
-   An fcntl lock stress tester from Bull, targetting NFSv4 locks
+   An fcntl lock stress tester from Bull, targeting NFSv4 locks
    http://nfsv4.bullopensource.org/tools/tests/page39.php
 
  * PyNFS

--- a/src/doc/coding_style/doxygen.txt
+++ b/src/doc/coding_style/doxygen.txt
@@ -59,7 +59,7 @@ and a description of the return value.  If the function is void, do
 not include a @return tag.  As with files, if the @brief description
 conveys all information worth conveying about the function, do not
 include a long comment and skip directly from the @brief description
-to the paremters.  Here is an example:
+to the parameters.  Here is an example:
 
 /**
  * @brief Do some stuff

--- a/src/doc/man/ganesha-cache-config.rst
+++ b/src/doc/man/ganesha-cache-config.rst
@@ -18,7 +18,7 @@ NFS-Ganesha reads the configuration data from:
 
 This file lists NFS-Ganesha Cache config options.  These options used to be
 configured in the CACHEINODE block.  They may still be used in that block, but
-it is deprecated and will go away.  The MDCACHE block takes precidence over the
+it is deprecated and will go away.  The MDCACHE block takes precedence over the
 CACHEINODE block.
 
 MDCACHE {}
@@ -72,7 +72,7 @@ Reaper_Work(uint32, range 1 to 2000, default 0)
     setting is deprecated.  Please use Reaper_Work_Per_Lane*
 
 Reaper_Work_Per_Lane(uint32, range 1 to UINT32_MAX, default 50)
-    This is the numer of handles per lane to scan when performing LRU
+    This is the number of handles per lane to scan when performing LRU
     maintenance.  This task is performed by the Reaper thread.
 
 Biggest_Window(uint32, range 1 to 100, default 40)

--- a/src/doc/man/ganesha-core-config.rst
+++ b/src/doc/man/ganesha-core-config.rst
@@ -62,7 +62,7 @@ Plugins_Dir(path, default "/usr/lib64/ganesha")
     Path to the directory containing server specific modules
 
 Enable_NFS_Stats(bool, default true)
-    Whether to collect perfomance statistics. By default the perfomance
+    Whether to collect performance statistics. By default the performance
     counting is enabled. Enable_NFS_Stats can be enabled or disabled
     dynamically via ganesha_stats.
 
@@ -133,7 +133,7 @@ mount_path_pseudo(bool, default false)
     new setups, it's strongly recommended to be set true since it then means
     the same server path for the mount is used for both v3 and v4.x.
 
-    Note that as an export related option, it seems very desireable to be
+    Note that as an export related option, it seems very desirable to be
     able to change this on config reload, unfortunately, at the moment it
     is NOT changeable on config reload. A restart is necessary to change this.
 
@@ -248,7 +248,7 @@ Enable_TCP_keepalive(bool, default true)
 TCP_KEEPCNT(UINT32, range 0 to 255, default 0 -> use system defaults)
     Maximum number of TCP probes before dropping the connection
 
-TCP_KEEPIDLE(UINT32, range 0 to 65535, default 0 -> use system defautls)
+TCP_KEEPIDLE(UINT32, range 0 to 65535, default 0 -> use system defaults)
     Idle time before TCP starts to send keepalive probes
 
 TCP_KEEPINTVL(INT32, range 0 to 65535, default 0 -> use system defaults)

--- a/src/doc/man/ganesha-export-config.rst
+++ b/src/doc/man/ganesha-export-config.rst
@@ -74,7 +74,7 @@ All options below are dynamically changeable with config update unless specified
 below.
 
 Export_id (required):
-    An identifier for the export, must be unique and betweem 0 and 65535.
+    An identifier for the export, must be unique and between 0 and 65535.
     If Export_Id 0 is specified, Pseudo must be the root path (/).
 
     Export_id is not dynamic per se, changing it essentially removes the old
@@ -346,7 +346,7 @@ Note that an EXPORT { CLIENT {} } block is not necessary if the default export
 pernmissions are workable.
 
 Note that in order for an EXPORT to be usable with NSFv4 it MUST either have
-Protcols = 4 specified in the EXPORT block, or the EXPORT block must not have
+Protocols = 4 specified in the EXPORT block, or the EXPORT block must not have
 the Protocols option at all such that it defaults to 3,4,9P. Note though that
 if it is not set and EXPORT_DEFAULTS just has Protocols = 3; then even though
 the export is mounted in the Pseudo Filesystem, it will not be accessible and

--- a/src/doc/man/ganesha-export-config.rst
+++ b/src/doc/man/ganesha-export-config.rst
@@ -89,7 +89,7 @@ Path (required)
     access the first export configured. To access other exports the
     Tag option would need to be used.
 
-    This option is NOT dunamically updateable since it fundamentally changes
+    This option is NOT dynamically updateable since it fundamentally changes
     the export. To change the path exported, export_id should be changed also.
 
 Pseudo (required v4)
@@ -343,7 +343,7 @@ correct way to accomplish this is:
     }
 
 Note that an EXPORT { CLIENT {} } block is not necessary if the default export
-pernmissions are workable.
+permissions are workable.
 
 Note that in order for an EXPORT to be usable with NSFv4 it MUST either have
 Protocols = 4 specified in the EXPORT block, or the EXPORT block must not have

--- a/src/doc/man/ganesha-lustre-config.rst
+++ b/src/doc/man/ganesha-lustre-config.rst
@@ -13,7 +13,7 @@ SYNOPSIS
 DESCRIPTION
 ==========================================================
 
-NFS-Ganesha installa the config example for LUSTRE FSAL:
+NFS-Ganesha installs the config example for LUSTRE FSAL:
 | /etc/ganesha/lustre.conf
 
 This file lists LUSTRE specific config options.
@@ -26,7 +26,7 @@ Name(string, "lustre")
 
 **async_hsm_restore(bool, default true)**
 
-All options of VFS export and module could be used for a FSAL_LUSTRE exporti and module.
+All options of VFS export and module could be used for a FSAL_LUSTRE export and module.
 :doc:`ganesha-vfs-config <ganesha-vfs-config>`\(8)
 
 See also

--- a/src/doc/man/ganesha-rados-cluster-design.rst
+++ b/src/doc/man/ganesha-rados-cluster-design.rst
@@ -157,7 +157,7 @@ server typically manages its own flags.
 
 The rados_cluster backend stores all of this information in a single
 RADOS object that is modified using read/modify/write cycles. Typically
-we'll read the whole object, modify it, and then attept to write it
+we'll read the whole object, modify it, and then attempt to write it
 back. If something changes between the read and write, we redo the read
 and try it again.
 

--- a/src/doc/man/ganesha-vfs-config.rst
+++ b/src/doc/man/ganesha-vfs-config.rst
@@ -48,7 +48,7 @@ VFS {}
 
 **auth_xdev_export(bool, default false)**
 
-**only_one_user(bool, default fasle)**
+**only_one_user(bool, default false)**
 
 See also
 ==============================


### PR DESCRIPTION
This mostly fixes the documentation under `src/doc/`. I may fix the API documentation in a different pull request. 

I have not fixed the typos in [`ChangeLog`](https://github.com/nfs-ganesha/nfs-ganesha/blob/next/src/ChangeLog).