### PR TITLE
selinux: Remove hard dependency on ceph module

### DIFF
--- a/src/selinux/ganesha.if
+++ b/src/selinux/ganesha.if
@@ -205,3 +205,99 @@ ifndef(`glusterd_dbus_chat',`
 		allow glusterd_t $1:dbus send_msg;
 	')
 ')
+
+########################################
+#
+# Interface compatibility blocks
+#
+# The following definitions ensure compatibility with distribution policy
+# versions that do not contain given interfaces (epel, or older Fedora
+# releases).
+# Each block tests for existence of given interface and defines it if needed.
+#
+
+########################################
+## <summary>
+##	Read ceph lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`ceph_read_lib_files',`
+	interface(`ceph_read_lib_files',`
+		gen_require(`
+			type ceph_var_lib_t;
+		')
+
+		files_search_var_lib($1)
+		read_files_pattern($1, ceph_var_lib_t, ceph_var_lib_t)
+	')
+')
+
+########################################
+## <summary>
+##	Search ceph lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`ceph_search_lib',`
+	interface(`ceph_search_lib',`
+		gen_require(`
+			type ceph_var_lib_t;
+		')
+
+		allow $1 ceph_var_lib_t:dir search_dir_perms;
+		files_search_var_lib($1)
+	')
+')
+
+########################################
+## <summary>
+##	Read ceph PID files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`ceph_read_pid_files',`
+	interface(`ceph_read_pid_files',`
+		gen_require(`
+			type ceph_var_run_t;
+		')
+
+		files_search_pids($1)
+		read_files_pattern($1, ceph_var_run_t, ceph_var_run_t)
+	')
+')
+
+########################################
+## <summary>
+##	Manage ceph log files
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`ceph_manage_log',`
+	interface(`ceph_manage_log',`
+		gen_require(`
+			type ceph_log_t;
+		')
+
+		logging_search_logs($1)
+		manage_dirs_pattern($1, ceph_log_t, ceph_log_t)
+		manage_files_pattern($1, ceph_log_t, ceph_log_t)
+		manage_lnk_files_pattern($1, ceph_log_t, ceph_log_t)
+	')
+')

--- a/src/selinux/ganesha.te
+++ b/src/selinux/ganesha.te
@@ -50,9 +50,6 @@ require {
 
 	type cluster_t;
 
-	type ceph_t;
-	type ceph_log_t;
-
 	class dbus send_msg;
 }
 
@@ -192,8 +189,6 @@ tunable_policy(`ganesha_use_fusefs',`
 #
 
 #============= ganesha_t ==============
-allow ganesha_t ceph_log_t:dir { add_name search write };
-allow ganesha_t ceph_log_t:file { create open };
 fs_read_cgroup_files(ganesha_t)
 
 #!!!! This avc can be allowed using the boolean 'domain_can_mmap_files'
@@ -209,8 +204,14 @@ allow init_t var_lib_nfs_t:dir { create setattr };
 #
 
 #!!!! This avc can be allowed using the boolean 'daemons_enable_cluster_mode'
-allow ganesha_t ceph_t:unix_stream_socket connectto;
+# there is no suitable interface in ceph policy module
+optional_policy(`
+    gen_require(`
+        type ceph_t;
+    ')
 
+    allow ganesha_t ceph_t:unix_stream_socket connectto;
+')
 
 ########################################
 #
@@ -324,22 +325,20 @@ optional_policy(`
 #
 # ganesha local policy rhbz#1855350
 
-ifdef(`ceph_read_lib_files',`
-    optional_policy(`
-        ceph_read_lib_files(ganesha_t)
-    ')
+optional_policy(`
+    ceph_read_lib_files(ganesha_t)
 ')
 
-ifdef(`ceph_search_lib',`
-    optional_policy(`
-        ceph_search_lib(ganesha_t)
-    ')
+optional_policy(`
+    ceph_search_lib(ganesha_t)
 ')
 
-ifdef(`ceph_read_pid_files',`
-    optional_policy(`
-        ceph_read_pid_files(ganesha_t)
-    ')
+optional_policy(`
+    ceph_read_pid_files(ganesha_t)
+')
+
+optional_policy(`
+    ceph_manage_log(ganesha_t)
 ')
 
 ########################################


### PR DESCRIPTION
Since ceph policy is shipped as a standalone package ceph-selinux, there
either needs to be dependency (Requires: ceph-selinux and BuildRequires:
ceph-selinux), or the policy has to be treated as "optional".

Note:
  Using ifdef around interface calls causes the interfaces not to be
  used at all when they are not found in the system (i.e. there are no
  policy rules based on the interfaces in the compiled policy).
  Instead we should ensure they are always available (ideally by adding
  BuildRequires: ceph-selinux, in this case I also added conditional
  definitions of needed ceph interfaces).

Fixes:
```
  ceph-selinux is not present in the system
  # dnf install nfs-ganesha-selinux
  ...
  Running scriptlet: nfs-ganesha-selinux-4.0-5.fc37.noarch                                                                                               9/10
  Installing       : nfs-ganesha-selinux-4.0-5.fc37.noarch                                                                                               9/10
  Running scriptlet: nfs-ganesha-selinux-4.0-5.fc37.noarch                                                                                               9/10
  Failed to resolve typeattributeset statement at /var/lib/selinux/targeted/tmp/modules/200/ganesha/cil:64
  Failed to resolve AST
  /usr/sbin/semodule:  Failed!

  # bzip2 -d /var/lib/selinux/packages/ganesha.pp.bz2
  # sudo /usr/libexec/selinux/hll/pp /var/lib/selinux/packages/ganesha.pp >> ganesha.cil
  # sed -n 64p ganesha/cil
  (typeattributeset cil_gen_require ceph_t)
  ^^^ corresponds to require { type ceph_t } in ganesha.te
```

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>