### PR TITLE
Readdir by chunk performance optimization.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ SET(RUNTIMEDIR "${SYSSTATEDIR}/run/ganesha" CACHE PATH "Runtime directory (for t
 # Extra version is for naming development/RC.  It is blank in stable branches
 # so it can be available to end-users to name local variants/versions
 # If used, it is always of the form "-whateveryouwant"
-set(GANESHA_EXTRA_VERSION .11)
+set(GANESHA_EXTRA_VERSION .12)
 
 set(GANESHA_VERSION ${GANESHA_MAJOR_VERSION}${GANESHA_MINOR_VERSION}${GANESHA_EXTRA_VERSION})
 set(GANESHA_BASE_VERSION ${GANESHA_MAJOR_VERSION}${GANESHA_MINOR_VERSION})

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_ext.h
@@ -70,6 +70,9 @@ struct mdcache_parameter {
 	/** High water mark for cache entries.  Defaults to 100000,
 	    settable by Entries_HWMark. */
 	uint32_t entries_hwmark;
+	/** Recovery time for readdir by chunk.  Defaults to 600s,
+	    settable by Recovery_Interval. */
+	uint32_t recovery_interval;
 	/** When the handle cache is over the high water mark, attempt to
 	    release this number of entries in each pass until it's back below
 	    the high water mark. Set it to 0 does not attempt to release

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
@@ -3175,6 +3175,8 @@ again:
 					"Lookup by key for %s failed, lookup by name now",
 					dirent->name);
 
+			chunk_dirty_manage.dirty_enable = true;
+			now(&chunk_dirty_manage.dirty_time);
 			/* mdc_lookup_uncached needs write lock, dropping the
 			 * read lock means we can no longer trust the dirent or
 			 * the chunk.

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_lru.h
@@ -93,6 +93,22 @@ struct lru_state {
 	uint32_t fd_state;
 };
 
+/**
+ * @brief Chunk would be set dirty if entries cache exist in chunks but
+ * not in global avl. 
+ * @section DESCRIPTION
+ * This is chunk dirty management unit which manage when chunk set dirty
+ * and restored.
+ *
+ */
+struct chunk_dirty_manage{
+	bool dirty_enable;
+	struct timespec dirty_time;
+	uint32_t recovery_interval; /*In seconds*/
+};
+
+extern struct chunk_dirty_manage chunk_dirty_manage;
+
 extern struct lru_state lru_state;
 
 /** Cache entries pool */

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_read_conf.c
@@ -70,6 +70,8 @@ static struct config_item mdcache_params[] = {
 		       mdcache_parameter, entries_release_size),
 	CONF_ITEM_UI32("Chunks_HWMark", 1, UINT32_MAX, 100000,
 		       mdcache_parameter, chunks_hwmark),
+	CONF_ITEM_UI32("Recovery_Interval", 1, 24 * 3600, 600,
+		       mdcache_parameter, recovery_interval),
 	CONF_ITEM_UI32("LRU_Run_Interval", 1, 24 * 3600, 90,
 		       mdcache_parameter, lru_run_interval),
 	CONF_ITEM_UI32("FD_Limit_Percent", 0, 100, 99,

--- a/src/doc/man/ganesha-cache-config.rst
+++ b/src/doc/man/ganesha-cache-config.rst
@@ -51,6 +51,9 @@ Entries_Release_Size(uint32, range 0 to UINT32_MAX, default 100)
 Chunks_HWMark(uint32, range 1 to UINT32_MAX, default 100000)
     The point at which dirent cache chunks will start being reused.
 
+Recovery_Interval(uint32, range 1 to 24 * 3600, default 600)
+    Readdir by chunk, if chunk is set dirty because of cache miss, recovery interval of readdir by chunk again.
+
 LRU_Run_Interval(uint32, range 1 to 24 * 3600, default 90)
     Base interval in seconds between runs of the LRU cleaner thread.
 


### PR DESCRIPTION
Readdir by chunk is slow if the number of file is large, and Entries_HWMark of configuration is not large enough. It fills all files to chunks in the directory under the current offset at one time, but noly read a part of chunk in a readdir. The entries cache in chunks may can't find in global avl which causes release the chunk and refill chunks again.
Add the chunk dirty detection mechanism. If the chunk has set dirty, go to the readdir uncached branch next readdir, and recover to the read chunk after a period of time(default 10 minutes).

Signed-off-by: iamtiger51 <1140520975@qq.com>