### PR TITLE
doc: fix cmount_path doc

### DIFF
--- a/src/doc/man/ganesha-ceph-config.rst
+++ b/src/doc/man/ganesha-ceph-config.rst
@@ -44,7 +44,10 @@ sec_label_xattr(char, default "security.selinux xattr of the file")
 
 cmount_path(string, no default)
     If specified, the path within the ceph filesystem to mount this
-    export on. It must be a subset of the EXPORT { Path } parameter.
+    export on. It is allowed to be up to the EXPORT { Path } parameter
+    hierarchy (i.e. if EXPORT { Path } parameter is `/foo/bar` then
+    cmount_path could be `/`, `/foo` or `/foo/bar`).
+
     If this and the other EXPORT { FSAL {} } options are the same
     between multiple exports, those exports will share a single
     cephfs client. With the default, this effectively defaults to


### PR DESCRIPTION
The line "It must be a subset of the EXPORT { Path } parameter" is really confusing, everytime i read it, it always implied that it must a subpath of the path parameter i.e. if the path = /foo/bar then the cmount_path's base|source|root is /foo/bar and it cannot go up to the hierachy i.e. it cannot be /foo or /.




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
