### PR TITLE
ceph_fsal_setattr2 should skip check_share_conflict if open_correct returns true

### DIFF
--- a/src/FSAL/FSAL_CEPH/handle.c
+++ b/src/FSAL/FSAL_CEPH/handle.c
@@ -2789,7 +2789,7 @@ static fsal_status_t ceph_fsal_setattr2(struct fsal_obj_handle *obj_hdl,
 	/* Test if size is being set, make sure file is regular and if so,
 	 * require a read/write file descriptor.
 	 */
-	if (state != NULL &&
+	if (state == NULL &&
 	    FSAL_TEST_MASK(attrib_set->valid_mask, ATTR_SIZE)) {
 		if (obj_hdl->type != REGULAR_FILE) {
 			LogFullDebug(COMPONENT_FSAL,


### PR DESCRIPTION

#1144



<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
