### PR TITLE
   Fix GLUSTER FSAL resource release order issue

### DIFF
--- a/src/FSAL/FSAL_GLUSTER/handle.c
+++ b/src/FSAL/FSAL_GLUSTER/handle.c
@@ -64,8 +64,6 @@ static void handle_release(struct fsal_obj_handle *obj_hdl)
 	now(&s_time);
 #endif
 
-	fsal_obj_handle_fini(&objhandle->handle, true);
-
 	if (obj_hdl->type == REGULAR_FILE) {
 		fsal_status_t st;
 
@@ -78,6 +76,8 @@ static void handle_release(struct fsal_obj_handle *obj_hdl)
 				st.minor);
 		}
 	}
+
+	fsal_obj_handle_fini(&objhandle->handle, true);
 
 	if (my_fd->creds.caller_garray) {
 		gsh_free(my_fd->creds.caller_garray);


### PR DESCRIPTION
   Adjust the order of resource release in handle_release to prevent
   null pointer access when closing file descriptors.

During debugging, we encountered a critical null pointer dereference issue. Under specific conditions, when processing objects that already exist in cache during directory read operations, the GLUSTER FSAL's _handle_release_ function would call _fsal_obj_handle_fini()_ before _close_fsal_fd()_. Since _fsal_obj_handle_fini()_ sets _obj_ops_ to NULL, this caused a null pointer access when _close_fsal_fd()_ tried to access _obj_hdl->obj_ops->close_func_.  as follows:

```
(gdb) bt
#0  close_fsal_fd (obj_hdl=0x7fa93858c030, fsal_fd=0x7fa93858bf38, is_reclaiming=false) at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/commonlib.c:2048
#1  0x00007fa9af2b85f3 in handle_release (obj_hdl=0x7fa93858c030) at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/FSAL_GLUSTER/handle.c:72
#2  0x00007fa9b21fb0e9 in mdcache_new_entry (export=0x1a00f30, sub_handle=0x7fa93858c030, attrs_in=0x7fa974ff7370, prefer_attrs_in=false, attrs_out=0x0, new_directory=false, entry=0x7fa974ff7220, state=0x0, flags=4)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c:948
#3  0x00007fa9b21ff6fc in mdc_readdir_chunk_object (name=0x7fa974ff7483 "README-keepalived.md", sub_handle=0x7fa93858c030, attrs_in=0x7fa974ff7370, dir_state=0x7fa974ff7760, cookie=33)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c:2187
#4  0x00007fa9b22008a1 in mdc_readdir_chunked_cb (name=0x7fa974ff7483 "README-keepalived.md", sub_handle=0x7fa93858c030, attrs=0x7fa974ff7370, dir_state=0x7fa974ff7760, cookie=33)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c:2465
#5  0x00007fa9af2b9877 in read_dirents (dir_hdl=0x7fa9800063f0, whence=0x7fa974ff7750, dir_state=0x7fa974ff7760, cb=0x7fa9b22007d5 <mdc_readdir_chunked_cb>, attrmask=9223372036889501678, eof=0x7fa974ff79c7)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/FSAL_GLUSTER/handle.c:407
#6  0x00007fa9b22010df in mdcache_populate_dir_chunk (directory=0x7fa9800064d0, whence=0, dirent=0x7fa974ff79c8, prev_chunk=0x0, eod_met=0x7fa974ff79c7) at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c:2647
#7  0x00007fa9b2202674 in mdcache_readdir_chunked (directory=0x7fa9800064d0, whence=0, dir_state=0x7fa974ff7b60, cb=0x7fa9b209d40a <populate_dirent>, attrmask=122830, eod_met=0x7fa974ff7ff3)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c:3002
#8  0x00007fa9b21ea934 in mdcache_readdir (dir_hdl=0x7fa980006508, whence=0x7fa974ff7b40, dir_state=0x7fa974ff7b60, cb=0x7fa9b209d40a <populate_dirent>, attrmask=122830, eod_met=0x7fa974ff7ff3)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c:573
#9  0x00007fa9b209ddd5 in fsal_readdir (directory=0x7fa980006508, cookie=0, nbfound=0x7fa974ff7ff4, eod_met=0x7fa974ff7ff3, attrmask=122830, cb=0x7fa9b21d57f6 <nfs3_readdirplus_callback>, opaque=0x7fa974ff7f40)
    at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/FSAL/fsal_helper.c:1380
#10 0x00007fa9b21d541f in nfs3_readdirplus (arg=0x7fa93818b8d8, req=0x7fa93818b0a0, res=0x7fa938533e70) at /usr/src/debug/nfs-ganesha-6.0-0.1.x86_64/Protocols/NFS/nfs3_readdirplus.c:312

(gdb) p obj_hdl->obj_ops
$6 = (struct fsal_obj_ops *) 0x0
```

Root Cause
The root cause was the incorrect order of resource release in the handle_release function. The function called fsal_obj_handle_fini() first, which cleared obj_ops, and then attempted to close file descriptors, leading to access of released resources.
Solution
We adjusted the resource release order in the handle_release function to ensure all accesses to obj_ops are completed before calling fsal_obj_handle_fini(). The specific changes are:

1. First check if it's a regular file and call close_fsal_fd() to close file descriptors
2. Then call fsal_obj_handle_fini() to clean up the object
3. Finally release other related resources

This fix follows the general principle of resource release: release specific resources (such as file descriptors) first, then release the object itself.

Testing

This fix has been verified in a test environment and resolves the null pointer access issue while maintaining the integrity of existing functionality.
Fixes a critical issue that could cause NFS-Ganesha service crashes. This PR is recommended for prompt merging.

Fixes #1328 
